### PR TITLE
adding base url

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -34,12 +34,12 @@ def _st(st):
         raise ValueError('Invalid type: %s' % st)
 
 
-def create_root_node(text, parser_cls):
+def create_root_node(text, parser_cls, base_url=None):
     """Create root node for text using given parser class.
     """
     body = text.strip().encode('utf8') or b'<html/>'
     parser = parser_cls(recover=True, encoding='utf8')
-    return etree.fromstring(body, parser=parser)
+    return etree.fromstring(body, parser=parser, base_url=base_url)
 
 
 class Selector(object):
@@ -61,7 +61,8 @@ class Selector(object):
     }
     _lxml_smart_strings = False
 
-    def __init__(self, text=None, type=None, namespaces=None, root=None, _expr=None):
+    def __init__(self, text=None, type=None, namespaces=None, root=None,
+                 base_url=None, _expr=None):
         self.type = st = _st(type or self._default_type)
         self._parser = _ctgroup[st]['_parser']
         self._csstranslator = _ctgroup[st]['_csstranslator']
@@ -70,7 +71,7 @@ class Selector(object):
         if text is not None:
             if not isinstance(text, six.text_type):
                 raise TypeError("text argument should be of type %s" % six.text_type)
-            root = self._get_root(text)
+            root = self._get_root(text, base_url)
         elif root is None:
             raise ValueError("Selector needs either text or root argument")
 
@@ -80,8 +81,8 @@ class Selector(object):
         self.root = root
         self._expr = _expr
 
-    def _get_root(self, text):
-        return create_root_node(text, self._parser)
+    def _get_root(self, text, base_url=None):
+        return create_root_node(text, self._parser, base_url=base_url)
 
     def xpath(self, query):
         try:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -373,6 +373,10 @@ class SelectorTestCase(unittest.TestCase):
 
         self.assertEqual(sel.extract(), '<foo>&xxe;</foo>')
 
+    def test_configure_base_url(self):
+        sel = self.sscls(text=u'nothing', base_url='http://example.com')
+        self.assertEquals(u'http://example.com', sel.root.base)
+
 
 class ExsltTestCase(unittest.TestCase):
 


### PR DESCRIPTION
So, the motivation for this is that we use selector.base_url in Scrapy here: https://github.com/scrapy/scrapy/blob/master/scrapy/http/request/form.py#L46 (where `form` is a Selector), and until now we were ignoring URLs in Parsel.

This needs to be agreed and merged in order to finish cleanly the Scrapy migration to Parsel, using the `create_root_node` there.