### PR TITLE
updating classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,11 @@ setup(
     zip_safe=False,
     keywords='parsel',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
+        'Topic :: Text Processing :: Markup',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Hey fellows,

This fixes the pre-alpha classifier (see #18) and also add `Topic :: Text Processing :: Markup`.

We can consider it stable since v1.0, Scrapy is even depending on the current API already.

Also, maybe we could add the more specific `Topic :: Text Processing :: Markup :: HTML` and `Topic :: Text Processing :: Markup :: XML` too (see [list of classifiers here](https://pypi.python.org/pypi?:action=list_classifiers)).

What do you think?

Thanks!