### PR TITLE
Travis: enable py3.5, disable pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-python: 2.7
+python: 3.5
 env:
   - TOXENV=py27
-  - TOXENV=pypy
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
 
 install:
   - pip install -U tox twine wheel codecov


### PR DESCRIPTION
Hey folks!
So it turns out lxml never really worked in pypy, so we should disable it from tests -- see issue #35