### PR TITLE
[MRG+1] exception handling was hiding original exception

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -2,6 +2,8 @@
 XPath selectors based on lxml
 """
 
+import sys
+
 import six
 from lxml import etree
 
@@ -175,9 +177,10 @@ class Selector(object):
         try:
             result = xpathev(query, namespaces=self.namespaces,
                              smart_strings=self._lxml_smart_strings)
-        except etree.XPathError:
-            msg = u"Invalid XPath: %s" % query
-            raise ValueError(msg if six.PY3 else msg.encode("unicode_escape"))
+        except etree.XPathError as exc:
+            msg = u"XPath error: %s in %s" % (exc, query)
+            msg = msg if six.PY3 else msg.encode('unicode_escape')
+            six.reraise(ValueError, ValueError(msg), sys.exc_info()[2])
 
         if type(result) is not list:
             result = [result]


### PR DESCRIPTION
Any xpath error was caught and reraised as a ValueError
complaining about an Invalid XPath,
quoting the original xpath for debugging purposes.

First, "Invalid XPath" is misleading
because the same exception is also raised for xpath evaluation errors.
However it also hides the original exception message
which ends up making xpath debugging harder.
I made it quote the original exception message too
which can be "Unregisted function", "Invalid Expression",
"Undefined namespace prefix" etc.

Now before merging:
Any exception can occur during xpath evaluation
because any python function can be registered and called in an xpath.
I doubt there's anyone wrapping xpath method calls in user code
in another try/except blocks for "ValueError".
Even if somebody actually does this,
I bet it's for logging some custom error message
and this can't justify the usefulness of the current try/except block.
That's why I'm leaning more towards dropping the try/except altogether.
However I opened this PR instead because I doubt you'd accept dropping it.