### PR TITLE
Update history, add release checklist and other doc improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+1.0.2 (2016-04-26)
+------------------
+
+* Fix bug in exception handling causing original traceback to be lost
+* Added docstrings and other doc fixes
+
 1.0.1 (2015-08-24)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include AUTHORS.rst
 include CONTRIBUTING.rst
-include HISTORY.rst
+include NEWS
 include LICENSE
 include README.rst
 

--- a/NEWS
+++ b/NEWS
@@ -4,58 +4,58 @@ History
 -------
 
 1.0.2 (2016-04-26)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Fix bug in exception handling causing original traceback to be lost
 * Added docstrings and other doc fixes
 
 1.0.1 (2015-08-24)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Updated PyPI classifiers
 * Added docstrings for csstranslator module and other doc fixes
 
 
 1.0.0 (2015-08-22)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Documentation fixes
 
 
 0.9.6 (2015-08-14)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Updated documentation
 * Extended test coverage
 
 
 0.9.5 (2015-08-11)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Support for extending SelectorList
 
 
 0.9.4 (2015-08-10)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Try workaround for travis-ci/dpl#253
 
 
 0.9.3 (2015-08-07)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Add base_url argument
 
 
 0.9.2 (2015-08-07)
-------------------
+~~~~~~~~~~~~~~~~~~
 
 * Rename module unified -> selector and promoted root attribute
 * Add create_root_node function
 
 
 0.9.1 (2015-08-04)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * Setup Sphinx build and docs structure
 * Build universal wheels
@@ -63,6 +63,6 @@ History
 
 
 0.9.0 (2015-07-30)
----------------------
+~~~~~~~~~~~~~~~~~~
 
 * First release on PyPI.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,0 +1,2 @@
+.. include:: ../NEWS
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,15 +3,16 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Parsel's documentation!
-======================================
+.. include:: ../README.rst
+
+Parsel Documentation Contents
+=============================
 
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
-   readme
    installation
    usage
    history

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,2 @@
+.. include:: ../README.rst
+

--- a/release.rst
+++ b/release.rst
@@ -1,0 +1,9 @@
+Release procedures
+------------------
+
+* Update NEWS file with the release notes
+* Run bumpversion with the proper release type
+* Push code and tags to GitHub to trigger build
+* Copy release notes to https://github.com/scrapy/parsel/releases
+* Verify in a temporary virtualenv that ``pip install parsel`` installs the
+  latest version

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('NEWS') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 test_requirements = [


### PR DESCRIPTION
Summary of changes:

* updated history/news
* renamed HISTORY.rst -> NEWS (convention in Scrapy and w3lib)
* add a release checklist
* show the readme in first page of documentation site

About the first page changes, here is the before...
![selection_2016-04-27_10 00 20](https://cloud.githubusercontent.com/assets/37565/14852812/0d35263a-0c5f-11e6-82f4-6ef5b89ad854.jpg)
And after:
![selection_2016-04-27_10 00 35](https://cloud.githubusercontent.com/assets/37565/14852818/19c5d8a4-0c5f-11e6-9415-599360bb45f2.jpg)

Looks good?

Thank you!