### PR TITLE
[MRG+1] Expose lxml.html.HTMLParser as an optional parser.

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -5,7 +5,7 @@ XPath selectors based on lxml
 import sys
 
 import six
-from lxml import etree
+from lxml import etree, html
 
 from .utils import flatten, iflatten, extract_regex
 from .csstranslator import HTMLTranslator, GenericTranslator
@@ -17,6 +17,9 @@ class SafeXMLParser(etree.XMLParser):
         super(SafeXMLParser, self).__init__(*args, **kwargs)
 
 _ctgroup = {
+    'html_html': {'_parser': html.HTMLParser,
+                  '_csstranslator': HTMLTranslator(),
+                  '_tostring_method': 'html'},
     'html': {'_parser': etree.HTMLParser,
              '_csstranslator': HTMLTranslator(),
              '_tostring_method': 'html'},

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -132,6 +132,19 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(xs.xpath("//div").extract(),
                          [u'<div><img src="a.jpg"><p>Hello</p></img></div>'])
 
+    def test_type_html_and_html_html_are_equal(self):
+        # some text which is parsed differently by XML and HTML flavors
+        text = u'<div><img src="a.jpg"><p>Hello</div>'
+        hs = self.sscls(text=text, type='html')
+        hhs = self.sscls(text=text, type='html_html')
+        self.assertEqual(hs.xpath("//div").extract(), hhs.xpath("//div").extract())
+
+    def test_html_html_element_class(self):
+        hhs = self.sscls(text=u'', type='html_html')
+        # The main different is that this class have additional handy methods
+        # for html text.
+        self.assertTrue(hasattr(hhs.root, 'make_links_absolute'))
+
     def test_error_for_unknown_selector_type(self):
         self.assertRaises(ValueError, self.sscls, text=u'', type='_na_')
 


### PR DESCRIPTION
The usefulness of this option is to be able to use helper methods from
the lxml.html.HTMLElement element class. For example, to make all links
absolute:

```
>>> import parsel
>>> sel = parsel.Selector(u'<a href="foo"></a>',
base_url="http://example.com/", type='html_html')
>>> sel.root.make_links_absolute()
>>> sel.xpath('//a/@href').extract()
[u'http://example.com/foo']
```

The type name `html_html` comes from the parser location `lxml.html.HTMLParser`.
