### PR TITLE
Added command line interface.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,10 @@ Example::
             print(e.xpath('.//a/@href').extract_first())
     http://example.com
     http://scrapy.org
+
+CLI example::
+
+    $ curl http://scrapy.org/ | python -m parsel --xpath '//a/@href' | tail -3
+    https://twitter.com/ScrapyProject
+    http://scrapinghub.com
+    http://github.com/scrapy/scrapy/graphs/contributors

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,6 +47,12 @@ defines selectors to associate those styles with specific HTML elements.
 You can use either language you're more comfortable with, though you may find
 that in some specific cases `XPath`_ is more powerful than `CSS`_.
 
+There is also a command line interface where you can test CSS/XPath expressions
+against HTML content. See::
+
+    python -m parsel --help
+
+
 .. _XPath: http://www.w3.org/TR/xpath
 .. _CSS: http://www.w3.org/TR/selectors
 

--- a/parsel/__main__.py
+++ b/parsel/__main__.py
@@ -1,0 +1,64 @@
+"""Parsel command line interface."""
+from __future__ import print_function, unicode_literals
+
+import argparse
+import pprint
+import re
+import sys
+
+import six
+
+from . import Selector, __version__
+
+
+def main(argv=None, progname=None):
+    parser = argparse.ArgumentParser(prog=progname, description=__doc__)
+    parser.add_argument('expr', metavar='EXPRESSION',
+                        help="A CSSexpression, or a XPath expression if --xpath is given.")
+    parser.add_argument('file', metavar='FILE', nargs='?',
+                        help="If missing, it reads the HTML content from the standard input.")
+    parser.add_argument('--xpath', action='store_true',
+                        help="Given expression is a XPath expression.")
+    parser.add_argument('--re', metavar='PATTERN',
+                        help="Apply given regular expression.")
+    parser.add_argument('--encoding', metavar='ENCODING', default='utf-8',
+                        help="Input encoding. Default: utf-8.")
+    parser.add_argument('--repr', action='store_true',
+                        help="Output result object representation instead of as text.")
+    parser.add_argument('-v', '--version', action='version', version=__version__)
+
+    args = parser.parse_args(argv)
+
+    if args.file:
+        text = open(args.file).read()
+    else:
+        text = sys.stdin.read()
+
+    if isinstance(text, six.binary_type):
+        try:
+            text = text.decode(args.encoding)
+        except UnicodeDecodeError:
+            parser.error("Failed to decode input using encoding: %s" % args.encoding)
+
+    sel = Selector(text=text)
+
+    if args.xpath:
+        result = sel.xpath(args.expr)
+    else:
+        result = sel.css(args.expr)
+
+    if args.re:
+        regex = args.re.encode(args.encoding)
+        regex = regex.decode('string_escape' if six.PY2 else 'unicode_escape')
+        out = result.re(re.compile(regex, re.IGNORECASE | re.UNICODE))
+    else:
+        out = result.extract()
+
+    if args.repr:
+        pprint.pprint(out)
+    else:
+        print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main(progname='python -m parsel')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,69 @@
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+
+import six
+
+from parsel.__main__ import main
+
+
+HTML = u"""
+    <div><a href="foo">bar</a></div>
+""".encode('utf-8')
+
+
+@contextlib.contextmanager
+def capture(stdin=None, encoding='utf-8'):
+    orig_stdin, orig_stdout = sys.stdin, sys.stdout
+    if six.PY2:
+        sys.stdin = stdin or six.StringIO()
+        sys.stdout = six.StringIO()
+    else:
+        sys.stdin = io.TextIOWrapper(stdin or io.BytesIO(), encoding=encoding)
+        sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+    try:
+        yield sys.stdout
+    finally:
+        sys.stdin = orig_stdin
+        sys.stdout = orig_stdout
+
+
+class MainTestCase(unittest.TestCase):
+
+    def test_default_arguments(self):
+        argv = ['a::attr(href)']
+        with capture(stdin=io.BytesIO(HTML)) as stdout:
+            main(argv)
+
+        stdout.seek(0)
+        self.assertEqual(stdout.read(), u'foo\n')
+
+    def test_default_arguments_from_file(self):
+        argv = ['a::attr(href)']
+        with tempfile.NamedTemporaryFile(delete=True) as fp:
+            fp.write(HTML)
+            fp.flush()
+            argv.append(fp.name)
+            with capture() as stdout:
+                main(argv)
+
+            stdout.seek(0)
+            self.assertEqual(stdout.read(), u'foo\n')
+
+    def test_with_all_arguments(self):
+        argv = [
+            '--re',
+            '(foo|bar)',
+            '--xpath',
+            '//a[@href]',
+            '--encoding',
+            'latin1',
+            '--repr',
+        ]
+        with capture(stdin=io.BytesIO(HTML)) as stdout:
+            main(argv)
+
+        stdout.seek(0)
+        self.assertEqual(eval(stdout.read()), ['foo', 'bar'])


### PR DESCRIPTION
```
$ python -m parsel --help
usage: python -m parsel [-h] [--xpath] [--re PATTERN] [--encoding ENCODING]
                        [--repr] [-v]
                        EXPRESSION [FILE]

Parsel command line interface.

positional arguments:
  EXPRESSION           A CSSexpression, or a XPath expression if --xpath is
                       given.
  FILE                 If missing, it reads the HTML content from the standard
                       input.

optional arguments:
  -h, --help           show this help message and exit
  --xpath              Given expression is a XPath expression.
  --re PATTERN         Apply given regular expression.
  --encoding ENCODING  Input encoding. Default: utf-8.
  --repr               Output result object representation instead of as text.
  -v, --version        show program's version number and exit

$ curl http://scrapy.org/ | python -m parsel --xpath '//a/@href'  | sort | uniq -c
   1 http://scrapy.org
   1 ../community/
   2 ../companies/
   1 ../doc/
   1 ../download/
   1 ../support/
   1 http://codecov.io/github/scrapy/scrapy?branch=master
   1 http://doc.scrapy.org/en/1.1/intro/overview.html
   1 http://doc.scrapy.org/en/latest/faq.html
   1 http://doc.scrapy.org/en/latest/topics/ubuntu.html
   1 http://github.com/scrapy/scrapy/graphs/contributors
   1 http://pypi.python.org/pypi/Scrapy
   1 http://scrapinghub.com
   1 http://scrapinghub.com/scrapy-cloud/
   1 http://stackoverflow.com/tags/scrapy/info
   1 https://anaconda.org/scrapinghub/scrapy
   2 https://github.com/scrapy/scrapy
   1 https://github.com/scrapy/scrapy/archive/1.1.zip
   1 https://github.com/scrapy/scrapy/wiki/Python-3-Porting
   1 https://github.com/scrapy/scrapyd
   1 https://groups.google.com/forum/?fromgroups#!aboutgroup/scrapy-users
   3 https://pypi.python.org/pypi/Scrapy
   2 https://twitter.com/ScrapyProject

```