### PR TITLE
[MRG+2] Support ad-hoc namespaces declarations and XPath variables

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -58,7 +58,7 @@ class SelectorList(list):
         o = super(SelectorList, self).__getitem__(pos)
         return self.__class__(o) if isinstance(pos, slice) else o
 
-    def xpath(self, xpath, namespaces={}, **kwargs):
+    def xpath(self, xpath, namespaces=None, **kwargs):
         """
         Call the ``.xpath()`` method for each element in this list and return
         their results flattened as another :class:`SelectorList`.
@@ -166,7 +166,7 @@ class Selector(object):
     def _get_root(self, text, base_url=None):
         return create_root_node(text, self._parser, base_url=base_url)
 
-    def xpath(self, query, namespaces={}, **kwargs):
+    def xpath(self, query, namespaces=None, **kwargs):
         """
         Find nodes matching the xpath ``query`` and return the result as a
         :class:`SelectorList` instance with all elements flattened. List
@@ -185,7 +185,8 @@ class Selector(object):
             return self.selectorlist_cls([])
 
         nsp = dict(self.namespaces)
-        nsp.update(namespaces)
+        if namespaces is not None:
+            nsp.update(namespaces)
         try:
             result = xpathev(query, namespaces=nsp,
                              smart_strings=self._lxml_smart_strings,

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -69,6 +69,11 @@ class SelectorList(list):
         for additional prefixes to those registered with ``register_namespace(prefix, uri)``.
         Contrary to ``register_namespace()``, these prefixes are not
         saved for future calls.
+
+        Any additional named argument can be used to pass values for XPath
+        variables in the XPath expression, e.g.:
+
+            selector.xpath('//a[href=$url]', url="http://www.example.com")
         """
         return self.__class__(flatten([x.xpath(xpath, namespaces=namespaces, **kwargs) for x in self]))
 
@@ -178,6 +183,11 @@ class Selector(object):
         for additional prefixes to those registered with ``register_namespace(prefix, uri)``.
         Contrary to ``register_namespace()``, these prefixes are not
         saved for future calls.
+
+        Any additional named argument can be used to pass values for XPath
+        variables in the XPath expression, e.g.:
+
+            selector.xpath('//a[href=$url]', url="http://www.example.com")
         """
         try:
             xpathev = self.root.xpath

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -58,14 +58,14 @@ class SelectorList(list):
         o = super(SelectorList, self).__getitem__(pos)
         return self.__class__(o) if isinstance(pos, slice) else o
 
-    def xpath(self, xpath):
+    def xpath(self, xpath, **kwargs):
         """
         Call the ``.xpath()`` method for each element in this list and return
         their results flattened as another :class:`SelectorList`.
 
         ``query`` is the same argument as the one in :meth:`Selector.xpath`
         """
-        return self.__class__(flatten([x.xpath(xpath) for x in self]))
+        return self.__class__(flatten([x.xpath(xpath, **kwargs) for x in self]))
 
     def css(self, xpath):
         """
@@ -161,7 +161,7 @@ class Selector(object):
     def _get_root(self, text, base_url=None):
         return create_root_node(text, self._parser, base_url=base_url)
 
-    def xpath(self, query):
+    def xpath(self, query, **kwargs):
         """
         Find nodes matching the xpath ``query`` and return the result as a
         :class:`SelectorList` instance with all elements flattened. List
@@ -175,8 +175,11 @@ class Selector(object):
             return self.selectorlist_cls([])
 
         try:
-            result = xpathev(query, namespaces=self.namespaces,
-                             smart_strings=self._lxml_smart_strings)
+            nsp = dict(self.namespaces)
+            nsp.update(kwargs.pop('namespaces', {}))
+            result = xpathev(query, namespaces=nsp,
+                             smart_strings=self._lxml_smart_strings,
+                             **kwargs)
         except etree.XPathError as exc:
             msg = u"XPath error: %s in %s" % (exc, query)
             msg = msg if six.PY3 else msg.encode('unicode_escape')

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -70,7 +70,7 @@ class SelectorList(list):
         Contrary to ``register_namespace()``, these prefixes are not
         saved for future calls.
 
-        Any additional named argument can be used to pass values for XPath
+        Any additional named arguments can be used to pass values for XPath
         variables in the XPath expression, e.g.:
 
             selector.xpath('//a[href=$url]', url="http://www.example.com")
@@ -184,7 +184,7 @@ class Selector(object):
         Contrary to ``register_namespace()``, these prefixes are not
         saved for future calls.
 
-        Any additional named argument can be used to pass values for XPath
+        Any additional named arguments can be used to pass values for XPath
         variables in the XPath expression, e.g.:
 
             selector.xpath('//a[href=$url]', url="http://www.example.com")

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -58,14 +58,19 @@ class SelectorList(list):
         o = super(SelectorList, self).__getitem__(pos)
         return self.__class__(o) if isinstance(pos, slice) else o
 
-    def xpath(self, xpath, **kwargs):
+    def xpath(self, xpath, namespaces={}, **kwargs):
         """
         Call the ``.xpath()`` method for each element in this list and return
         their results flattened as another :class:`SelectorList`.
 
         ``query`` is the same argument as the one in :meth:`Selector.xpath`
+
+        ``namespaces`` is an optional ``prefix: namespace-uri`` mapping (dict)
+        for additional prefixes to those registered with ``register_namespace(prefix, uri)``.
+        Contrary to ``register_namespace()``, these prefixes are not
+        saved for future calls.
         """
-        return self.__class__(flatten([x.xpath(xpath, **kwargs) for x in self]))
+        return self.__class__(flatten([x.xpath(xpath, namespaces=namespaces, **kwargs) for x in self]))
 
     def css(self, xpath):
         """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -161,22 +161,27 @@ class Selector(object):
     def _get_root(self, text, base_url=None):
         return create_root_node(text, self._parser, base_url=base_url)
 
-    def xpath(self, query, **kwargs):
+    def xpath(self, query, namespaces={}, **kwargs):
         """
         Find nodes matching the xpath ``query`` and return the result as a
         :class:`SelectorList` instance with all elements flattened. List
         elements implement :class:`Selector` interface too.
 
         ``query`` is a string containing the XPATH query to apply.
+
+        ``namespaces`` is an optional ``prefix: namespace-uri`` mapping (dict)
+        for additional prefixes to those registered with ``register_namespace(prefix, uri)``.
+        Contrary to ``register_namespace()``, these prefixes are not
+        saved for future calls.
         """
         try:
             xpathev = self.root.xpath
         except AttributeError:
             return self.selectorlist_cls([])
 
+        nsp = dict(self.namespaces)
+        nsp.update(namespaces)
         try:
-            nsp = dict(self.namespaces)
-            nsp.update(kwargs.pop('namespaces', {}))
             result = xpathev(query, namespaces=nsp,
                              smart_strings=self._lxml_smart_strings,
                              **kwargs)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -47,6 +47,34 @@ class SelectorTestCase(unittest.TestCase):
                                    number=2, letter='a').extract(),
                          [u'2.0'])
 
+        # you can also pass booleans
+        self.assertEqual(sel.xpath("boolean(count(//input)=$cnt)=$test",
+                                   cnt=2, test=True).extract(),
+                         [u'1'])
+        self.assertEqual(sel.xpath("boolean(count(//input)=$cnt)=$test",
+                                   cnt=4, test=True).extract(),
+                         [u'0'])
+        self.assertEqual(sel.xpath("boolean(count(//input)=$cnt)=$test",
+                                   cnt=4, test=False).extract(),
+                         [u'1'])
+
+        # for named nodes, you need to use "name()=node_name"
+        self.assertEqual(sel.xpath("boolean(count(//*[name()=$tag])=$cnt)=$test",
+                                   tag="input", cnt=2, test=True).extract(),
+                         [u'1'])
+
+    def test_simple_selection_with_variables_escape_friendly(self):
+        """Using XPath variables with quotes that would need escaping with string formatting"""
+        body = u"""<p>I'm mixing single and <input name='a' value='I say "Yeah!"'/>
+        "double quotes" and I don't care :)</p>"""
+        sel = self.sscls(text=body)
+
+        self.assertEqual([x.extract() for x in sel.xpath("//input[@value=$text]/@name", text='I say "Yeah!"')],
+                         [u'a'])
+        self.assertEqual([x.extract() for x in sel.xpath("//p[normalize-space()=$lng]//@name",
+            lng="""I'm mixing single and "double quotes" and I don't care :)""")],
+                         [u'a'])
+
     def test_representation_slice(self):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')
         sel = self.sscls(text=body)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -69,10 +69,21 @@ class SelectorTestCase(unittest.TestCase):
         "double quotes" and I don't care :)</p>"""
         sel = self.sscls(text=body)
 
-        self.assertEqual([x.extract() for x in sel.xpath("//input[@value=$text]/@name", text='I say "Yeah!"')],
+        t = 'I say "Yeah!"'
+        # naive string formatting with give something like:
+        # ValueError: XPath error: Invalid predicate in //input[@value="I say "Yeah!""]/@name
+        self.assertRaises(ValueError, sel.xpath, '//input[@value="{}"]/@name'.format(t))
+
+        # with XPath variables, escaping is done for you
+        self.assertEqual([x.extract() for x in sel.xpath("//input[@value=$text]/@name", text=t)],
                          [u'a'])
+        lt = """I'm mixing single and "double quotes" and I don't care :)"""
+        # the following gives you something like
+        # ValueError: XPath error: Invalid predicate in //p[normalize-space()='I'm mixing single and "double quotes" and I don't care :)']//@name
+        self.assertRaises(ValueError, sel.xpath, "//p[normalize-space()='{}']//@name".format(lt))
+
         self.assertEqual([x.extract() for x in sel.xpath("//p[normalize-space()=$lng]//@name",
-            lng="""I'm mixing single and "double quotes" and I don't care :)""")],
+            lng=lt)],
                          [u'a'])
 
     def test_representation_slice(self):


### PR DESCRIPTION
[XPath variables are part of XPath 1.0](https://www.w3.org/TR/xpath/#section-Basics):

> A VariableReference (`'$' QName`) evaluates to the value to which the variable name is bound in the set of variable bindings in the context. It is an error if the variable name is not bound to any value in the set of variable bindings in the expression context.

And [`lxml` supports them](http://lxml.de/xpathxslt.html)

> The xpath() method has support for XPath variables:

```
>>> expr = "//*[local-name() = $name]"
>>> print(root.xpath(expr, name = "foo")[0].tag)
foo
>>> print(root.xpath(expr, name = "bar")[0].tag)
bar
>>> print(root.xpath("$text", text = "Hello World!"))
Hello World!
(...)
>>> count_elements = etree.XPath("count(//*[local-name() = $name])")
>>> print(count_elements(root, name = "a"))
1.0
>>> print(count_elements(root, name = "b"))
2.0
```

The PR allows passing variables as keyword arguments.

While at it, it also add the possibility to update prefix mapping for namespaces on `.xpath()` calls

Missing:
- [x] update docs
