### PR TITLE
Integrate py.test runs with setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal=1
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
+    setup_requires=['pytest-runner',],
+    tests_require=['pytest',],
     test_suite='tests',
 )


### PR DESCRIPTION
Following instructions from
http://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

This is what you get:

```
(parsel-pytest-setup) paul@paul:~/src/parsel$ python setup.py test
running pytest
Searching for cssselect>=0.9
Best match: cssselect 0.9.2
Processing cssselect-0.9.2-py2.7.egg

Using /home/paul/src/parsel/.eggs/cssselect-0.9.2-py2.7.egg
Searching for six>=1.5.2
Best match: six 1.10.0
Processing six-1.10.0-py2.7.egg

Using /home/paul/src/parsel/.eggs/six-1.10.0-py2.7.egg
Searching for lxml
Best match: lxml 3.6.1
Processing lxml-3.6.1-py2.7-linux-x86_64.egg

Using /home/paul/src/parsel/.eggs/lxml-3.6.1-py2.7-linux-x86_64.egg
Searching for w3lib>=1.8.0
Best match: w3lib 1.14.3
Processing w3lib-1.14.3-py2.7.egg

Using /home/paul/src/parsel/.eggs/w3lib-1.14.3-py2.7.egg
Searching for pytest
Best match: pytest 2.9.2
Processing pytest-2.9.2-py2.7.egg

Using /home/paul/src/parsel/.eggs/pytest-2.9.2-py2.7.egg
Searching for py>=1.4.29
Best match: py 1.4.31
Processing py-1.4.31-py2.7.egg

Using /home/paul/src/parsel/.eggs/py-1.4.31-py2.7.egg
running egg_info
writing requirements to parsel.egg-info/requires.txt
writing parsel.egg-info/PKG-INFO
writing top-level names to parsel.egg-info/top_level.txt
writing dependency_links to parsel.egg-info/dependency_links.txt
reading manifest file 'parsel.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'AUTHORS.rst'
warning: no files found matching 'CONTRIBUTING.rst'
warning: no previously-included files matching '__pycache__' found under directory '*'
writing manifest file 'parsel.egg-info/SOURCES.txt'
running build_ext
===================================================================================== test session starts ======================================================================================
platform linux2 -- Python 2.7.12, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/paul/src/parsel, inifile: pytest.ini
collected 53 items 

parsel/utils.py ..
tests/test_selector.py ..................s......................
tests/test_selector_csstranslator.py ..........

============================================================================= 52 passed, 1 skipped in 0.11 seconds =============================================================================
(parsel-pytest-setup) paul@paul:~/src/parsel$ 
```