### PR TITLE
[MRG+1] Change default parser to html.HTMLParser

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -5,7 +5,7 @@ XPath selectors based on lxml
 import sys
 
 import six
-from lxml import etree
+from lxml import etree, html
 
 from .utils import flatten, iflatten, extract_regex
 from .csstranslator import HTMLTranslator, GenericTranslator
@@ -17,7 +17,7 @@ class SafeXMLParser(etree.XMLParser):
         super(SafeXMLParser, self).__init__(*args, **kwargs)
 
 _ctgroup = {
-    'html': {'_parser': etree.HTMLParser,
+    'html': {'_parser': html.HTMLParser,
              '_csstranslator': HTMLTranslator(),
              '_tostring_method': 'html'},
     'xml': {'_parser': SafeXMLParser,

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -232,6 +232,12 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(x.xpath("//p:SecondTestTag").xpath("./xmlns:price/text()")[0].extract(), '90')
         self.assertEqual(x.xpath("//p:SecondTestTag/xmlns:material/text()").extract()[0], 'iron')
 
+    def test_make_links_absolute(self):
+        text = u'<a href="file.html">link to file</a>'
+        sel = Selector(text=text, base_url='http://example.com')
+        sel.root.make_links_absolute()
+        self.assertEqual(u'http://example.com/file.html', sel.xpath('//a/@href').extract_first())
+
     def test_re(self):
         body = u"""<div>Name: Mary
                     <ul>


### PR DESCRIPTION
This is a separate PR (alternative to #54) just for changing the default parser to lxml.html.HTMLParser as discussed in #40 and #41 .