### PR TITLE
[MRG+1] Add a css2xpath util function available at the top-level

### DIFF
--- a/parsel/__init__.py
+++ b/parsel/__init__.py
@@ -8,3 +8,4 @@ __email__ = 'info@scrapy.org'
 __version__ = '1.0.3'
 
 from parsel.selector import Selector, SelectorList  # NOQA
+from parsel.csstranslator import css2xpath  # NOQA

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -96,3 +96,11 @@ class GenericTranslator(TranslatorMixin, OriginalGenericTranslator):
 
 class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
     pass
+
+
+_translator = HTMLTranslator()
+
+
+def css2xpath(query):
+    "Return translated XPath version of a given CSS query"
+    return _translator.css_to_xpath(query)

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -113,6 +113,14 @@ class TranslatorMixinTest(unittest.TestCase):
             self.assertRaises(exc, self.c2x, css)
 
 
+class UtilCss2XPathTest(unittest.TestCase):
+    def test_css2xpath(self):
+        from parsel import css2xpath
+        expected_xpath = (u"descendant-or-self::*[@class and contains("
+                          "concat(' ', normalize-space(@class), ' '), ' some-class ')]")
+        self.assertEqual(css2xpath('.some-class'), expected_xpath)
+
+
 class CSSSelectorTest(unittest.TestCase):
 
     sscls = Selector


### PR DESCRIPTION
I've found useful a small util function to get a CSS query translated to XPath, for cases when I'm using an API that only accepts XPath but I want to use CSS at least for parts of an expression.

Here are some usage examples from recent code that might illustrate the usefulness:

* `css2xpath('.profileTopData') + '//h3`
* next_page_xpath = css2xpath('.paginationBar a') + '[./span[contains(@class, "next")]]/@href'

Does this look good to you?