### PR TITLE
[WIP] Support *:nth-of-type through XPath extension function

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -11,6 +11,23 @@ from .utils import flatten, iflatten, extract_regex
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
+def css_star_nth_of_type(context, a, b, preceding=True):
+    node = context.context_node
+    num_siblings = len(list(node.itersiblings(node.tag, preceding=preceding)))
+    if a:
+        return (num_siblings // a) == (b-1)
+    else:
+        return num_siblings == (b-1)
+
+
+def css_star_nth_last_of_type(context, a, b):
+    return css_star_nth_of_type(context, a, b, preceding=False)
+
+ns = etree.FunctionNamespace(None)
+ns['star-nth-of-type'] = css_star_nth_of_type
+ns['star-nth-last-of-type'] = css_star_nth_of_type
+
+
 class SafeXMLParser(etree.XMLParser):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('resolve_entities', False)

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -146,6 +146,11 @@ class CSSSelectorTest(unittest.TestCase):
         self.assertEqual(self.x('p::text'), [u'lorem ipsum text'])
         self.assertEqual(self.x('p ::text'), [u'lorem ipsum text', u'hi', u'there', u'guy'])
 
+    def test_text_star_nth_pseudo_class(self):
+        self.assertEqual(len(self.x('div *:nth-of-type(2)')), 5)
+        self.assertEqual(self.x('*:nth-last-of-type(7)::attr(id)'),
+                                ['checkbox-disabled-checked'])
+
     def test_attribute_function(self):
         self.assertEqual(self.x('#p-b2::attr(id)'), [u'p-b2'])
         self.assertEqual(self.x('.cool-footer::attr(class)'), [u'cool-footer'])


### PR DESCRIPTION
Very rough start at supporting `*:nth-of-type(an+b)`

https://github.com/scrapy/cssselect/issues/4 looks impossible to translate in pure XPath 1.0, but is doable with custom XPath functions.

To do:

- [ ] test more `an+b` cases
- [ ] test `*:first-of-type`, `*:last-of-type`, `*:only-of-type`
- [ ] test with namespaces
- [ ] refactor to use a namespace prefix and a seperate module for custom XPath functions (https://github.com/scrapy/parsel/issues/13#issuecomment-132038170 and subsequent comment)