### PR TITLE
[MRG+1] Add default parameter to re_first() method

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -97,7 +97,8 @@ class SelectorList(list):
         """
         Call the ``.re()`` method for the first element in this list and
         return the result in an unicode string. If the list is empty or the
-        regex doesn't match anything, return the default value.
+        regex doesn't match anything, return the default value (``None`` if
+        the argument is not provided).
         """
         for el in iflatten(x.re(regex) for x in self):
             return el

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -93,13 +93,16 @@ class SelectorList(list):
         """
         return flatten([x.re(regex) for x in self])
 
-    def re_first(self, regex):
+    def re_first(self, regex, default=None):
         """
         Call the ``.re()`` method for the first element in this list and
-        return the result in an unicode string.
+        return the result in an unicode string. If the list is empty or the
+        regex doesn't match anything, return the default value.
         """
         for el in iflatten(x.re(regex) for x in self):
             return el
+        else:
+            return default
 
     def extract(self):
         """

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -156,6 +156,14 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(sel.xpath('/ul/li/text()').re_first('\w+'), None)
         self.assertEqual(sel.xpath('/ul/li[@id="doesnt-exist"]/text()').re_first('\d'), None)
 
+    def test_extract_first_default(self):
+        """Test if re_first() returns default value when no results found"""
+        body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
+        sel = self.sscls(text=body)
+
+        self.assertEqual(sel.xpath('//div/text()').re_first('\w+', default='missing'), 'missing')
+        self.assertEqual(sel.xpath('/ul/li/text()').re_first('\w+', default='missing'), 'missing')
+
     def test_select_unicode_query(self):
         body = u"<p><input name='\xa9' value='1'/></p>"
         sel = self.sscls(text=body)


### PR DESCRIPTION
This adds a `default` parameter to the `re_first` method, whose value is returned when the method can't extract anything.

`extract_first()` already supports this parameter and it would be nice to have the same behavior for `re_first`.