### PR TITLE
Use more liberal requirements (for tox mainly)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml==3.4.4
-six==1.9.0
-cssselect==0.9.1
-w3lib==1.11.0
+lxml>=2.3
+six>=1.5.2
+cssselect>=0.9
+w3lib>=1.8.0


### PR DESCRIPTION
The minimal versions are the same as in `setup.py`