### PR TITLE
Move XML/HTML examples up one-level in the sections hierarchy

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -578,6 +578,8 @@ to use the ``.`` in the XPath expressions that will follow.
 API reference
 =============
 
+Selector objects
+----------------
 
 .. autoclass:: parsel.selector.Selector
     :members:
@@ -590,9 +592,10 @@ SelectorList objects
     :members:
 
 
+.. _selector-examples-html:
 
-Selector examples on HTML text
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Working on HTML
+---------------
 
 Here are some :class:`Selector` examples to illustrate several concepts.
 In all cases, we assume there is already a :class:`Selector` instantiated with
@@ -619,8 +622,8 @@ an HTML text like this::
 
 .. _selector-examples-xml:
 
-Selector examples on XML text
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Working on XML (and namespaces)
+-------------------------------
 
 Here are some examples to illustrate concepts for :class:`Selector` objects
 instantiated with an XML text like this::

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -71,7 +71,7 @@ class SelectorList(list):
         saved for future calls.
 
         Any additional named arguments can be used to pass values for XPath
-        variables in the XPath expression, e.g.:
+        variables in the XPath expression, e.g.::
 
             selector.xpath('//a[href=$url]', url="http://www.example.com")
         """
@@ -189,7 +189,7 @@ class Selector(object):
         saved for future calls.
 
         Any additional named arguments can be used to pass values for XPath
-        variables in the XPath expression, e.g.:
+        variables in the XPath expression, e.g.::
 
             selector.xpath('//a[href=$url]', url="http://www.example.com")
         """


### PR DESCRIPTION
Current hierarchy looks broken:

![image](https://cloud.githubusercontent.com/assets/886296/24915073/77537be0-1ed6-11e7-827e-59f946d005d7.png)

New layout:

![image](https://cloud.githubusercontent.com/assets/886296/24915122/9baf645e-1ed6-11e7-9dba-48e480bd29fa.png)
