### PR TITLE
Travis CI: use portable pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ install:
         else
           rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
         fi
-        # get latest PyPy from pyenv directly (thanks to natural version sort option -V)
-        export PYPY_VERSION=`"$PYENV_ROOT/bin/pyenv" install --list |grep -o -E 'pypy-[0-9][\.0-9]*$' |sort -V |tail -1`
+        # get latest (portable) PyPy from pyenv directly (thanks to natural version sort option -V)
+        export PYPY_VERSION=`"$PYENV_ROOT/bin/pyenv" install --list |grep -o -E 'pypy-portable-[0-9][\.0-9]*$' |sort -V |tail -1`
         "$PYENV_ROOT/bin/pyenv" install --skip-existing "$PYPY_VERSION"
         virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
         source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
       fi
-  - pip install -U tox twine wheel codecov
+  - pip install -U pip tox twine wheel codecov
 script: tox
 after_success:
   - codecov


### PR DESCRIPTION
Recent Travis builds against PyPy are failing: e.g. https://travis-ci.org/scrapy/parsel/jobs/220997016
(we're using pyenv to install a recent PyPy)

```
$ if [ "$TOXENV" = "pypy" ]; then
    export PYENV_ROOT="$HOME/.pyenv"
    if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
      pushd "$PYENV_ROOT" && git pull && popd
    else
      rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
    fi
    # get latest PyPy from pyenv directly (thanks to natural version sort option -V)
    export PYPY_VERSION=`"$PYENV_ROOT/bin/pyenv" install --list |grep -o -E 'pypy-[0-9][\.0-9]*$' |sort -V |tail -1`
    "$PYENV_ROOT/bin/pyenv" install --skip-existing "$PYPY_VERSION"
    virtualenv --python="$PYENV_ROOT/versions/$PYPY_VERSION/bin/python" "$HOME/virtualenvs/$PYPY_VERSION"
    source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
  fi
  
Cloning into '/home/travis/.pyenv'...
remote: Counting objects: 566, done.
remote: Compressing objects: 100% (432/432), done.
remote: Total 566 (delta 224), reused 253 (delta 45), pack-reused 0
Receiving objects: 100% (566/566), 250.89 KiB | 0 bytes/s, done.
Resolving deltas: 100% (224/224), done.
Checking connectivity... done.
Downloading pypy2-v5.7.1-linux64.tar.bz2...
-> https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.7.1-linux64.tar.bz2
Installing pypy2-v5.7.1-linux64...
WARNING: The Python readline extension was not compiled. Missing the GNU readline lib?
ERROR: The Python zlib extension was not compiled. Missing the zlib?
Please consult to the Wiki page to fix the problem.
https://github.com/pyenv/pyenv/wiki/Common-build-problems
```

I'm not sure how to properly fix installing pypy from source on Travis for pypy>=5.7, so I suggest that we use [the portable versions of PyPy for Linux](https://github.com/squeaky-pl/portable-pypy#portable-pypy-distribution-for-linux) that pyenv also supports.

Note: ~~building pypy 5.6.0 from source~~[installing from pypy2-v5.6.0-linux64.tar.bz2](https://travis-ci.org/scrapy/parsel/jobs/221007192) works fine on Travis.