### PR TITLE
Add .get() and .getall() aliases

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -111,6 +111,7 @@ class SelectorList(list):
         their results flattened, as a list of unicode strings.
         """
         return [x.extract() for x in self]
+    getall = extract
 
     def extract_first(self, default=None):
         """
@@ -121,6 +122,7 @@ class SelectorList(list):
             return x.extract()
         else:
             return default
+    get = extract_first
 
 
 class Selector(object):
@@ -260,6 +262,7 @@ class Selector(object):
                 return u'0'
             else:
                 return six.text_type(self.root)
+    get = extract
 
     def register_namespace(self, prefix, uri):
         """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -264,6 +264,12 @@ class Selector(object):
                 return six.text_type(self.root)
     get = extract
 
+    def getall(self):
+        """
+        Serialize and return the matched node in a 1-element list of unicode strings.
+        """
+        return [self.get()]
+
     def register_namespace(self, prefix, uri):
         """
         Register the given namespace to be used in this :class:`Selector`.

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -147,6 +147,14 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(sel.xpath('//ul/li[position()>1]')[0].get(), u'<li id="2">2</li>')
         self.assertEqual(sel.xpath('//ul/li[position()>1]/text()')[0].get(), u'2')
 
+    def test_selector_getall_alias(self):
+        """Test if get() returns extracted value on a Selector"""
+        body = u'<ul><li id="1">1</li><li id="2">2</li><li id="3">3</li></ul>'
+        sel = self.sscls(text=body)
+
+        self.assertListEqual(sel.xpath('//ul/li[position()>1]')[0].getall(), [u'<li id="2">2</li>'])
+        self.assertListEqual(sel.xpath('//ul/li[position()>1]/text()')[0].getall(), [u'2'])
+
     def test_selectorlist_get_alias(self):
         """Test if get() returns first element for a selection call"""
         body = u'<ul><li id="1">1</li><li id="2">2</li><li id="3">3</li></ul>'
@@ -261,7 +269,7 @@ class SelectorTestCase(unittest.TestCase):
                          ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
         self.assertEqual(divtwo.xpath("./li").extract(), [])
 
-    def test_getall_alias(self):
+    def test_selectorlist_getall_alias(self):
         """Nested selector tests using getall()"""
         body = u"""<body>
                     <div class='one'>

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -141,19 +141,19 @@ class SelectorTestCase(unittest.TestCase):
 
     def test_selector_get_alias(self):
         """Test if get() returns extracted value on a Selector"""
-        body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
+        body = u'<ul><li id="1">1</li><li id="2">2</li><li id="3">3</li></ul>'
         sel = self.sscls(text=body)
 
-        self.assertEqual(sel.xpath('//ul/li/text()')[0].get(),
-                         sel.xpath('//ul/li/text()')[0].extract()[0])
+        self.assertEqual(sel.xpath('//ul/li[position()>1]')[0].get(), u'<li id="2">2</li>')
+        self.assertEqual(sel.xpath('//ul/li[position()>1]/text()')[0].get(), u'2')
 
     def test_selectorlist_get_alias(self):
         """Test if get() returns first element for a selection call"""
-        body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
+        body = u'<ul><li id="1">1</li><li id="2">2</li><li id="3">3</li></ul>'
         sel = self.sscls(text=body)
 
-        self.assertEqual(sel.xpath('//ul/li/text()').get(),
-                         sel.xpath('//ul/li/text()').extract()[0])
+        self.assertEqual(sel.xpath('//ul/li').get(), u'<li id="1">1</li>')
+        self.assertEqual(sel.xpath('//ul/li/text()').get(), u'1')
 
     def test_re_first(self):
         """Test if re_first() returns first matched element"""

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -139,6 +139,22 @@ class SelectorTestCase(unittest.TestCase):
 
         self.assertEqual(sel.xpath('//div/text()').extract_first(default='missing'), 'missing')
 
+    def test_selector_get_alias(self):
+        """Test if get() returns extracted value on a Selector"""
+        body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
+        sel = self.sscls(text=body)
+
+        self.assertEqual(sel.xpath('//ul/li/text()')[0].get(),
+                         sel.xpath('//ul/li/text()')[0].extract()[0])
+
+    def test_selectorlist_get_alias(self):
+        """Test if get() returns first element for a selection call"""
+        body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
+        sel = self.sscls(text=body)
+
+        self.assertEqual(sel.xpath('//ul/li/text()').get(),
+                         sel.xpath('//ul/li/text()').extract()[0])
+
     def test_re_first(self):
         """Test if re_first() returns first matched element"""
         body = u'<ul><li id="1">1</li><li id="2">2</li></ul>'
@@ -244,6 +260,31 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(divtwo.xpath(".//li").extract(),
                          ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
         self.assertEqual(divtwo.xpath("./li").extract(), [])
+
+    def test_getall_alias(self):
+        """Nested selector tests using getall()"""
+        body = u"""<body>
+                    <div class='one'>
+                      <ul>
+                        <li>one</li><li>two</li>
+                      </ul>
+                    </div>
+                    <div class='two'>
+                      <ul>
+                        <li>four</li><li>five</li><li>six</li>
+                      </ul>
+                    </div>
+                  </body>"""
+
+        x = self.sscls(text=body)
+        divtwo = x.xpath('//div[@class="two"]')
+        self.assertEqual(divtwo.xpath("//li").getall(),
+                         ["<li>one</li>", "<li>two</li>", "<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath("./ul/li").getall(),
+                         ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath(".//li").getall(),
+                         ["<li>four</li>", "<li>five</li>", "<li>six</li>"])
+        self.assertEqual(divtwo.xpath("./li").getall(), [])
 
     def test_mixed_nested_selectors(self):
         body = u'''<body>


### PR DESCRIPTION
In quite a few projects, I've been using a `.get()` alias to `.extract_first()` as most of the time, getting the first match is what I want.
To me, `.extract_first()` feels a bit long to write (I'm probably getting lazy with age...)

For cases where I _do_ need to loop on results, I added a `.getall()` alias for `.extract()` on `.xpath()` and `.css()` calls results.

I know [there's been quite some discussion already](https://github.com/scrapy/scrapy/issues/568) to have `.extract_first()` in the first place, but I'm submitting my preference again.