### PR TITLE
[MRG+1] Better handling named groups in parsel.utils.extract_regex and error fix

### DIFF
--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -67,8 +67,12 @@ def extract_regex(regex, text):
 
     if 'extract' in regex.groupindex:
         # named group
-        searched = regex.search(text)
-        strings = [searched.group('extract')] if searched else []
+        try:
+            extracted = regex.search(text).group('extract')
+        except AttributeError:
+            strings = []
+        else:
+            strings = [extracted] if extracted is not None else []
     else:
         # full regex or numbered groups
         strings = regex.findall(text)

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -65,8 +65,11 @@ def extract_regex(regex, text):
     if isinstance(regex, six.string_types):
         regex = re.compile(regex, re.UNICODE)
 
-    try:
-        strings = [regex.search(text).group('extract')]   # named group
-    except:
-        strings = regex.findall(text)    # full regex or numbered groups
+    if 'extract' in regex.groupindex:
+        # named group
+        searched = regex.search(text)
+        strings = [searched.group('extract')] if searched else []
+    else:
+        # full regex or numbered groups
+        strings = regex.findall(text)
     return [replace_entities(s, keep=['lt', 'amp']) for s in flatten(strings)]

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -452,6 +452,15 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(x.xpath("//ul/li").re("Age: (\d+)"),
                          ["10", "20"])
 
+        # Test named group, hit and miss
+        x = self.sscls(text=u'foobar')
+        self.assertEqual(x.re('(?P<extract>foo)'), ['foo'])
+        self.assertEqual(x.re('(?P<extract>baz)'), [])
+
+        # A purposely constructed test for an edge case
+        x = self.sscls(text=u'baz')
+        self.assertEqual(x.re('(?P<extract>foo)|(?P<bar>baz)'), [])
+
     def test_re_intl(self):
         body = u'<div>Evento: cumplea\xf1os</div>'
         x = self.sscls(text=body)


### PR DESCRIPTION
Changes:
1. Added: Better handling named groups in `parsel.utils.extract_regex`
2. Fixed: Error extracting regex in some cases (see the example below)

An example when the current `extract_regex` does not handle it correctly:
```python
>>> import re
>>> re.search('(?P<extract>foo)|(?P<bar>baz)', 'baz').groups()
(None, 'baz')
>>> import parsel
>>> sel = parsel.Selector(text=u'baz')
>>> sel.re('(?P<extract>foo)|(?P<bar>baz)')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "parsel/selector.py", line 249, in re
    return extract_regex(regex, self.extract())
  File "parsel/utils.py", line 75, in extract_regex
    return [replace_entities(s, keep=['lt', 'amp']) for s in flatten(strings)]
  File "/usr/lib/python2.7/site-packages/w3lib/html.py", line 94, in replace_entities
    return _ent_re.sub(convert_entity, to_unicode(text, encoding))
  File "/usr/lib/python2.7/site-packages/w3lib/util.py", line 24, in to_unicode
    'object, got %s' % type(text).__name__)
TypeError: to_unicode must receive a bytes, str or unicode object, got NoneType
```