### PR TITLE
[MRG+1] Add has-class xpath extension function

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -450,6 +450,47 @@ inside another ``itemscope``.
 .. _regular expressions: http://exslt.org/regexp/index.html
 .. _set manipulation: http://exslt.org/set/index.html
 
+Other XPath extensions
+----------------------
+
+Parsel also defines a sorely missed XPath extension function ``has-class`` that
+returns ``True`` for nodes that have all of the specified HTML classes::
+
+    >>> from parsel import Selector
+    >>> sel = Selector("""
+    ...         <p class="foo bar-baz">First</p>
+    ...         <p class="foo">Second</p>
+    ...         <p class="bar">Third</p>
+    ...         <p>Fourth</p>
+    ... """)
+    ...
+    >>> sel = Selector(u"""
+    ...         <p class="foo bar-baz">First</p>
+    ...         <p class="foo">Second</p>
+    ...         <p class="bar">Third</p>
+    ...         <p>Fourth</p>
+    ... """)
+    ...
+    >>> sel.xpath('//p[has-class("foo")]')
+    [<Selector xpath='//p[has-class("foo")]' data=u'<p class="foo bar-baz">First</p>'>,
+     <Selector xpath='//p[has-class("foo")]' data=u'<p class="foo">Second</p>'>]
+    >>> sel.xpath('//p[has-class("foo", "bar-baz")]')
+    [<Selector xpath='//p[has-class("foo", "bar-baz")]' data=u'<p class="foo bar-baz">First</p>'>]
+    >>> sel.xpath('//p[has-class("foo", "bar")]')
+    []
+
+So XPath ``//p[has-class("foo", "bar-baz")]`` is roughly equivalent to CSS
+``p.foo.bar-baz``.  Please note, that it is slower in most of the cases,
+because it's a pure-Python function that's invoked for every node in question
+whereas the CSS lookup is translated into XPath and thus runs more efficiently,
+so performance-wise its uses are limited to situations that are not easily
+described with CSS selectors.
+
+Parsel also simplifies adding your own XPath extensions.
+
+.. autofunction:: parsel.xpathfuncs.set_xpathfunc
+
+
 
 Some XPath tips
 ---------------

--- a/parsel/__init__.py
+++ b/parsel/__init__.py
@@ -9,3 +9,6 @@ __version__ = '1.2.0'
 
 from parsel.selector import Selector, SelectorList  # NOQA
 from parsel.csstranslator import css2xpath  # NOQA
+from parsel import xpathfuncs # NOQA
+
+xpathfuncs.setup()

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -4,8 +4,15 @@ from lxml import etree
 def set_xpathfunc(fname, func):
     """Register a custom extension function to use in XPath expressions.
 
-    The function receives a "context" parameter as well as any parameters
-    passed from the corresponding XPath expression.
+    The function ``func`` registered under ``fname`` identifier will be called
+    for every matching node, being passed a ``context`` parameter as well as
+    any parameters passed from the corresponding XPath expression.
+
+    If ``func`` is ``None``, the extension function will be removed.
+
+    See more `in lxml documentation`_.
+
+    .. _`in lxml documentation`: http://lxml.de/extensions.html#xpath-extension-functions
 
     """
     ns_fns = etree.FunctionNamespace(None)

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -1,5 +1,7 @@
 from lxml import etree
 
+from six import string_types
+
 
 def set_xpathfunc(fname, func):
     """Register a custom extension function to use in XPath expressions.
@@ -32,6 +34,16 @@ def has_class(context, *classes):
     Return True if all ``classes`` are present in element's class attr.
 
     """
+    if not context.eval_context.get('args_checked'):
+        if not classes:
+            raise ValueError(
+                'XPath error: has-class must have at least 1 argument')
+        for c in classes:
+            if not isinstance(c, string_types):
+                raise ValueError(
+                    'XPath error: has-class arguments must be strings')
+        context.eval_context['args_checked'] = True
+
     node_cls = context.context_node.get('class')
     if node_cls is None:
         return False

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -1,11 +1,11 @@
 from lxml import etree
-from six import iteritems
+from six import iteritems, get_function_code
 
 _XPATH_FUNCS = {}
 
 
 def register(func):
-    fname = func.func_name.replace('_', '-')
+    fname = get_function_code(func).co_name.replace('_', '-')
     _XPATH_FUNCS[fname] = func
     return func
 

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -1,22 +1,24 @@
 from lxml import etree
-from six import iteritems, get_function_code
-
-_XPATH_FUNCS = {}
 
 
-def register(func):
-    fname = get_function_code(func).co_name.replace('_', '-')
-    _XPATH_FUNCS[fname] = func
-    return func
+def set_xpathfunc(fname, func):
+    """Register a custom extension function to use in XPath expressions.
+
+    The function receives a "context" parameter as well as any parameters
+    passed from the corresponding XPath expression.
+
+    """
+    ns_fns = etree.FunctionNamespace(None)
+    if func is not None:
+        ns_fns[fname] = func
+    else:
+        del ns_fns[fname]
 
 
 def setup():
-    fns = etree.FunctionNamespace(None)
-    for k, v in iteritems(_XPATH_FUNCS):
-        fns[k] = v
+    set_xpathfunc('has-class', has_class)
 
 
-@register
 def has_class(context, *classes):
     """has-class function.
 

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -1,0 +1,33 @@
+from lxml import etree
+from six import iteritems
+
+_XPATH_FUNCS = {}
+
+
+def register(func):
+    fname = func.func_name.replace('_', '-')
+    _XPATH_FUNCS[fname] = func
+    return func
+
+
+def setup():
+    fns = etree.FunctionNamespace(None)
+    for k, v in iteritems(_XPATH_FUNCS):
+        fns[k] = v
+
+
+@register
+def has_class(context, *classes):
+    """has-class function.
+
+    Return True if all ``classes`` are present in element's class attr.
+
+    """
+    node_cls = context.context_node.get('class')
+    if node_cls is None:
+        return False
+    node_cls = ' ' + node_cls + ' '
+    for cls in classes:
+        if ' ' + cls + ' ' not in node_cls:
+            return False
+    return True

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -1,5 +1,7 @@
 from parsel import Selector
+from parsel.xpathfuncs import set_xpathfunc
 import unittest
+
 
 class XPathFuncsTestCase(unittest.TestCase):
     def test_has_class_simple(self):
@@ -31,3 +33,27 @@ class XPathFuncsTestCase(unittest.TestCase):
         self.assertEqual(
             [x.extract() for x in sel.xpath('//p[has-class("foo")]/text()')],
             [u'First'])
+
+    def test_set_xpathfunc(self):
+
+        def myfunc(ctx):
+            myfunc.call_count += 1
+
+        myfunc.call_count = 0
+
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'Unregistered function in myfunc',
+            sel.xpath, 'myfunc()')
+
+        set_xpathfunc('myfunc', myfunc)
+        sel.xpath('myfunc()')
+        self.assertEqual(myfunc.call_count, 1)
+
+        set_xpathfunc('myfunc', None)
+        self.assertRaisesRegexp(
+            ValueError, 'Unregistered function in myfunc',
+            sel.xpath, 'myfunc()')

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -52,7 +52,7 @@ class XPathFuncsTestCase(unittest.TestCase):
         sel = Selector(text=body)
         self.assertRaisesRegexp(
             ValueError, 'All strings must be XML compatible',
-            sel.xpath, 'has-class("héllö")')
+            sel.xpath, u'has-class("héllö")'.encode('utf-8'))
 
     def test_has_class_unicode(self):
         body = u"""

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -1,0 +1,33 @@
+from parsel import Selector
+import unittest
+
+class XPathFuncsTestCase(unittest.TestCase):
+    def test_has_class_simple(self):
+        body = u"""
+        <p class="foo bar-baz">First</p>
+        <p class="foo">Second</p>
+        <p class="bar">Third</p>
+        <p>Fourth</p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//p[has-class("foo")]/text()')],
+            [u'First', u'Second'])
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//p[has-class("bar")]/text()')],
+            [u'Third'])
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//p[has-class("foo","bar")]/text()')],
+            [])
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//p[has-class("foo","bar-baz")]/text()')],
+            [u'First'])
+
+    def test_has_class_uppercase(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//p[has-class("foo")]/text()')],
+            [u'First'])

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from parsel import Selector
 from parsel.xpathfuncs import set_xpathfunc
 import unittest
@@ -23,6 +25,42 @@ class XPathFuncsTestCase(unittest.TestCase):
             [])
         self.assertEqual(
             [x.extract() for x in sel.xpath('//p[has-class("foo","bar-baz")]/text()')],
+            [u'First'])
+
+    def test_has_class_error_no_args(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'has-class must have at least 1 argument',
+            sel.xpath, 'has-class()')
+
+    def test_has_class_error_invalid_arg_type(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'has-class arguments must be strings',
+            sel.xpath, 'has-class(.)')
+
+    def test_has_class_error_invalid_unicode(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'All strings must be XML compatible',
+            sel.xpath, 'has-class("héllö")')
+
+    def test_has_class_unicode(self):
+        body = u"""
+        <p CLASS="fóó">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath(u'//p[has-class("fóó")]/text()')],
             [u'First'])
 
     def test_has_class_uppercase(self):


### PR DESCRIPTION
This is a POC implementation of what's been discussed in #13

The benchmark extended to include this implementation of `has-class` is available [here](https://gist.github.com/immerrr/6cbdcae303683203ddb44a0c1c18731e). To summarize its results, throughout this morning I have seen custom xpath functions (except the old `has-class`) implementations taking 150-200% of the css->xpath approach's time in the first test, and the last case, `sel.xpath('//*[has-class("story")]//a')`, took only 60% of `sel.css('.story').xpath('.//a')` time consistenly.

But right now I'm seeing a different situation:
```
$ python bench.py 
sel.css(".story")                                                       0.654  1.000
sel.xpath("//*[has-class-old('story')]")                               12.256 18.737
sel.xpath("//*[has-class-set('story')]")                                1.907  2.915
sel.xpath("//*[has-one-class('story')]")                                1.715  2.623
sel.xpath("//*[has-class-plain('story')]")                              1.770  2.706


sel.css("article.story")                                                0.201  1.000
sel.xpath("//article[has-class-old('story')]")                          1.219  6.072
sel.xpath("//article[has-class-set('story')]")                          0.314  1.566
sel.xpath("//article[has-one-class('story')]")                          0.292  1.454
sel.xpath("//article[has-class-plain('story')]")                        0.299  1.490


sel.css("article.theme-summary.story")                                  0.192  1.000
sel.xpath("//article[has-class-old('theme-summary', 'story')]")         1.288  6.699
sel.xpath("//article[has-class-set('theme-summary', 'story')]")         0.266  1.384
sel.xpath("//article[has-class-plain('theme-summary', 'story')]")       0.247  1.284


sel.css(".story").xpath(".//a")                                         1.798  1.000
sel.xpath("//*[has-class-old('story')]//a")                            11.995  6.671
sel.xpath("//*[has-class-set('story')]//a")                             1.944  1.081
sel.xpath("//*[has-one-class('story')]//a")                             1.747  0.972
sel.xpath("//*[has-class-plain('story')]//a")                           1.778  0.989
```

