### PR TITLE
Add rel-id xpath ext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Pytest
+/.cache

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -95,3 +95,64 @@ class XPathFuncsTestCase(unittest.TestCase):
         self.assertRaisesRegexp(
             ValueError, 'Unregistered function in myfunc',
             sel.xpath, 'myfunc()')
+
+    def test_rel_id_basic(self):
+        body = u"""
+        <foo><p id="foop">Foo</p></foo>
+        <bar><p id="barp">Bar</p></p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop")/text()')],
+            [u'Foo'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop", .)/text()')],
+            [u'Foo'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop", //foo)/text()')],
+            [u'Foo'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop", //p)/text()')],
+            [u'Foo'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop", //bar)/text()')],
+            [],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//foo').xpath('rel-id("foop")/text()')],
+            [u'Foo'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('//bar').xpath('rel-id("foop")/text()')],
+            [],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("barp", //bar)/text()')],
+            [u'Bar'],
+        )
+        self.assertEqual(
+            [x.extract() for x in sel.xpath('rel-id("foop", //zzz)/text()')],
+            [],
+        )
+
+    def test_rel_id_error_invalid_id(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'rel-id: first argument must be a string',
+            sel.xpath, u'rel-id(123)')
+
+    def test_rel_id_error_invalid_nodeset(self):
+        body = u"""
+        <p CLASS="foo">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertRaisesRegexp(
+            ValueError, 'rel-id: second argument must be a nodeset',
+            sel.xpath, u'rel-id("123", true())')


### PR DESCRIPTION
This PR adds an xpathfunc that performs relative `id` lookups.

There are two ways of doing those:
- `sel.xpath('id("foo")')` under the hood performs a dictionary lookup and thus is blazingly fast, however there's no way to limit the nodeset to search in.
- with `sel.xpath('//*[@id="foo"]')` one can limit the nodeset the way they like, however it has to traverse all the matching nodes, and thus is a lot slower

`rel-id` function, presented in this PR, attempts to achieve some middle ground: it does the `id` lookup under the hood, but then checks the result to be in the specified nodeset, i.e. all following statements return the same results:

```
sel.xpath('rel-id("foo", //div)')
sel.xpath('//div').xpath('rel-id("foo")')
sel.xpath('id("foo")[ancestor::div]')
sel.xpath('id("foo")[set:intersection(ancestor::*, //div)]')
sel.xpath('//div/*[@id="foo"]')
```

Naturally, it's a Python-level xpathfunc, so "native" solutions that involve `id` and `ancestor` are faster, but it's still more performant than `[@id="foo"]` and `.css("div #foo")` (that expands to `[@id="foo"]`):
```
sel.css("#masthead")                                                    0.971  1.000
sel.xpath("//*[@id='masthead']")                                        1.186  1.221
sel.xpath("id('masthead')")                                             0.032  0.033
sel.xpath("rel-id('masthead')")                                         0.051  0.053


sel.css("#shell #masthead")                                             2.162  1.000
sel.xpath("//*[@id='shell']//*[@id='masthead']")                        2.257  1.044
sel.xpath("id('shell')//*[@id='masthead']")                             1.147  0.531
sel.xpath("id('masthead')[ancestor::*[@id='shell']]")                   0.039  0.018
sel.xpath("id('masthead')[set:intersection(ancestor::*, id('shell'))]")  0.037  0.017
sel.xpath("rel-id('masthead', id('shell'))")                            0.055  0.025
sel.xpath("id('shell')").xpath("rel-id('masthead')")                    0.090  0.041


sel.css("div #masthead")                                               12.127  1.000
sel.xpath("id('masthead')[ancestor::div]")                              0.035  0.003
sel.xpath("rel-id('masthead', //div)")                                  0.558  0.046
sel.xpath("//div").xpath("rel-id('masthead')")                         17.939  1.479


sel.xpath("id('masthead')[set:intersection(ancestor::*, (//div|//span))]")  0.248  1.000
sel.xpath("rel-id('masthead', (//div|//span))")                         0.670  2.700
sel.xpath("//div|//span").xpath("rel-id('masthead')")                  19.825 79.845
```

The benchmark is available [here](https://gist.github.com/immerrr/2811f094b19986eda153b1585c2214c1). Also, `sel.xpath("//div").xpath("rel-id('masthead')")` and `sel.xpath("//div|//span").xpath("rel-id('masthead')")` are very slow because of the number of items for which `rel-id` is invoked.

One particular situation when `rel-id` is helpful, is when you pre-select a subset of the document and then look in its descendants:
```
sel2 = sel.xpath('id("foo")')
sel2.xpath('rel-id("bar")')
```
The `sel2.xpath('id("bar")[set:intersection(ancestor::*, .)]')` approach won't work here, because the dot inside the square brackets already means `id("bar")` rather than `id("foo")`.