### PR TITLE
WIP: Add support for xpath objs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Pytest
+/.cache

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -208,22 +208,30 @@ class Selector(object):
 
             selector.xpath('//a[href=$url]', url="http://www.example.com")
         """
-        try:
-            xpathev = self.root.xpath
-        except AttributeError:
-            return self.selectorlist_cls([])
+        if isinstance(query, etree.XPath):
+            try:
+                result = query(self.root, **kwargs)
+            except etree.XPathError as exc:
+                msg = u"XPath error: %s in %s" % (exc, query.path)
+                msg = msg if six.PY3 else msg.encode('unicode_escape')
+                six.reraise(ValueError, ValueError(msg), sys.exc_info()[2])
+        else:
+            try:
+                xpathev = self.root.xpath
+            except AttributeError:
+                return self.selectorlist_cls([])
 
-        nsp = dict(self.namespaces)
-        if namespaces is not None:
-            nsp.update(namespaces)
-        try:
-            result = xpathev(query, namespaces=nsp,
-                             smart_strings=self._lxml_smart_strings,
-                             **kwargs)
-        except etree.XPathError as exc:
-            msg = u"XPath error: %s in %s" % (exc, query)
-            msg = msg if six.PY3 else msg.encode('unicode_escape')
-            six.reraise(ValueError, ValueError(msg), sys.exc_info()[2])
+            nsp = dict(self.namespaces)
+            if namespaces is not None:
+                nsp.update(namespaces)
+            try:
+                result = xpathev(query, namespaces=nsp,
+                                 smart_strings=self._lxml_smart_strings,
+                                 **kwargs)
+            except etree.XPathError as exc:
+                msg = u"XPath error: %s in %s" % (exc, query)
+                msg = msg if six.PY3 else msg.encode('unicode_escape')
+                six.reraise(ValueError, ValueError(msg), sys.exc_info()[2])
 
         if type(result) is not list:
             result = [result]

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -665,6 +665,16 @@ class SelectorTestCase(unittest.TestCase):
         self.assertIsInstance(sel.css('div'), MySelectorList)
         self.assertIsInstance(sel.css('div')[0], MySelector)
 
+    def test_xpath_object(self):
+        body = u"<p><input name='a' value='1'/><input name='b' value='2'/></p>"
+        sel = self.sscls(text=body)
+        xpathstr = '//input[@name=$name]/@value'
+        self.assertEquals(sel.xpath(xpathstr, name='a').extract(), [u'1'])
+
+        from lxml.etree import XPath
+        xpath = XPath(xpathstr)
+        self.assertEquals(sel.xpath(xpath, name='a').extract(), [u'1'])
+
 class ExsltTestCase(unittest.TestCase):
 
     sscls = Selector


### PR DESCRIPTION
I have realized `lxml.etree.XPath` objects are not supported in Parsel, this is a PR that should fix this.