### PR TITLE
Add attributes dict accessor

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -137,21 +137,6 @@ class SelectorList(list):
             return default
     get = extract_first
 
-    def attrs(self):
-        """Return the attributes dictionary for the first element.
-        If the list is empty, return an empty dict.
-        """
-        for x in self:
-            return x.attrs()
-        else:
-            return {}
-
-    def attrs_all(self):
-        """Return a list that contains the attributes dictionary for
-        each underlying element.
-        """
-        return [x.attrs() for x in self]
-
 
 class Selector(object):
     """
@@ -339,16 +324,11 @@ class Selector(object):
             # remove namespace declarations
             etree.cleanup_namespaces(self.root)
 
-    def attrs(self):
+    @property
+    def attrib(self):
         """Return the attributes dictionary for underlying element.
         """
         return self.root.attrib
-
-    def attrs_all(self):
-        """Return a list containing the attributes dictionary for underlying element.
-        For consistency with :meth:`SelectorList.attrs_all`
-        """
-        return [self.attrs()]
 
     def __bool__(self):
         """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -137,6 +137,16 @@ class SelectorList(list):
             return default
     get = extract_first
 
+    @property
+    def attrib(self):
+        """Return the attributes dictionary for the first element.
+        If the list is empty, return an empty dict.
+        """
+        for x in self:
+            return x.attrib
+        else:
+            return {}
+
 
 class Selector(object):
     """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -338,7 +338,7 @@ class Selector(object):
     def attrib(self):
         """Return the attributes dictionary for underlying element.
         """
-        return self.root.attrib
+        return dict(self.root.attrib)
 
     def __bool__(self):
         """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -137,6 +137,21 @@ class SelectorList(list):
             return default
     get = extract_first
 
+    def attrs(self):
+        """Return the attributes dictionary for the first element.
+        If the list is empty, return an empty dict.
+        """
+        for x in self:
+            return x.attrs()
+        else:
+            return {}
+
+    def attrs_all(self):
+        """Return a list that contains the attributes dictionary for
+        each underlying element.
+        """
+        return [x.attrs() for x in self]
+
 
 class Selector(object):
     """
@@ -323,6 +338,17 @@ class Selector(object):
                     el.attrib[an.split('}', 1)[1]] = el.attrib.pop(an)
             # remove namespace declarations
             etree.cleanup_namespaces(self.root)
+
+    def attrs(self):
+        """Return the attributes dictionary for underlying element.
+        """
+        return self.root.attrib
+
+    def attrs_all(self):
+        """Return a list containing the attributes dictionary for underlying element.
+        For consistency with :meth:`SelectorList.attrs_all`
+        """
+        return [self.attrs()]
 
     def __bool__(self):
         """

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -86,6 +86,35 @@ class SelectorTestCase(unittest.TestCase):
             lng=lt)],
                          [u'a'])
 
+    def test_accessing_attributes(self):
+        body = u"""
+<html lang="en" version="1.0">
+    <body>
+        <ul id="some-list" class="list-cls" class="list-cls">
+            <li class="item-cls" id="list-item-1">
+            <li class="item-cls active" id="list-item-2">
+            <li class="item-cls" id="list-item-3">
+        </ul>
+    </body>
+</html>
+        """
+        sel = self.sscls(text=body)
+        self.assertEquals({'lang': 'en', 'version': '1.0'}, sel.attrs())
+
+        # .attrs on a SelectorList, brings the attributes of first-element only
+        self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul').attrs())
+        self.assertEquals({'class': 'item-cls', 'id': 'list-item-1'}, sel.css('li').attrs())
+
+        # for the attributes for all children, use attrs_all
+        self.assertEquals(
+            [{'class': 'item-cls', 'id': 'list-item-1'},
+             {'class': 'item-cls active', 'id': 'list-item-2'},
+             {'class': 'item-cls', 'id': 'list-item-3'}],
+            sel.css('li').attrs_all())
+
+        # for consistency, .attrs_all is also in Selector
+        self.assertEquals([{'class': 'item-cls', 'id': 'list-item-1'}], sel.css('li')[0].attrs_all())
+
     def test_representation_slice(self):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')
         sel = self.sscls(text=body)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -99,21 +99,14 @@ class SelectorTestCase(unittest.TestCase):
 </html>
         """
         sel = self.sscls(text=body)
-        self.assertEquals({'lang': 'en', 'version': '1.0'}, sel.attrs())
+        self.assertEquals({'lang': 'en', 'version': '1.0'}, sel.attrib)
+        self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul')[0].attrib)
 
-        # .attrs on a SelectorList, brings the attributes of first-element only
-        self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul').attrs())
-        self.assertEquals({'class': 'item-cls', 'id': 'list-item-1'}, sel.css('li').attrs())
-
-        # for the attributes for all children, use attrs_all
         self.assertEquals(
             [{'class': 'item-cls', 'id': 'list-item-1'},
              {'class': 'item-cls active', 'id': 'list-item-2'},
              {'class': 'item-cls', 'id': 'list-item-3'}],
-            sel.css('li').attrs_all())
-
-        # for consistency, .attrs_all is also in Selector
-        self.assertEquals([{'class': 'item-cls', 'id': 'list-item-1'}], sel.css('li')[0].attrs_all())
+            [e.attrib for e in sel.css('li')])
 
     def test_representation_slice(self):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -105,6 +105,8 @@ class SelectorTestCase(unittest.TestCase):
         # for a SelectorList, bring the attributes of first-element only
         self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul').attrib)
         self.assertEquals({'class': 'item-cls', 'id': 'list-item-1'}, sel.css('li').attrib)
+        self.assertEquals({}, sel.css('body').attrib)
+        self.assertEquals({}, sel.css('non-existing-element').attrib)
 
         self.assertEquals(
             [{'class': 'item-cls', 'id': 'list-item-1'},

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -102,6 +102,10 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEquals({'lang': 'en', 'version': '1.0'}, sel.attrib)
         self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul')[0].attrib)
 
+        # for a SelectorList, bring the attributes of first-element only
+        self.assertEquals({'id': 'some-list', 'class': 'list-cls'}, sel.css('ul').attrib)
+        self.assertEquals({'class': 'item-cls', 'id': 'list-item-1'}, sel.css('li').attrib)
+
         self.assertEquals(
             [{'class': 'item-cls', 'id': 'list-item-1'},
              {'class': 'item-cls active', 'id': 'list-item-2'},


### PR DESCRIPTION
It's often useful to get the attributes of the underlying elements, and Parsel currently doesn't make it obvious how to do that.

Currently, the first instinct is to use XPath, which makes it a bit awkward because [you need a trick like the `name(@*[i])` described in this blog post](https://blog.scrapinghub.com/2014/06/18/extracting-schema-org-microdata-using-scrapy-selectors-and-xpath/).

This PR proposes adding two methods `.attrs()` and `.attrs_all()` (mirroring `get` and `getall`) for getting attributes in a way that more or less made sense to me.
What do you think?