### PR TITLE
[MRG+1] add lru_cache to css2xpath

### DIFF
--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -1,4 +1,9 @@
-from functools import lru_cache
+import sys
+
+if sys.version_info[0] < 3:
+    from functools32 import lru_cache
+else:
+    from functools import lru_cache
 
 from cssselect import GenericTranslator as OriginalGenericTranslator
 from cssselect import HTMLTranslator as OriginalHTMLTranslator

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -102,6 +102,7 @@ class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
 
 _translator = HTMLTranslator()
 
+
 @functools.lru_cache(maxsize=128)
 def css2xpath(query):
     "Return translated XPath version of a given CSS query"

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -100,16 +100,12 @@ class TranslatorMixin(object):
 class GenericTranslator(TranslatorMixin, OriginalGenericTranslator):
     @lru_cache(maxsize=256)
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
-        return ' | '.join(self.selector_to_xpath(selector, prefix,
-                                                 translate_pseudo_elements=True)
-                          for selector in parse(css))
+        return super(GenericTranslator, self).css_to_xpath(css, prefix)
 
 class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
     @lru_cache(maxsize=256)
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
-        return ' | '.join(self.selector_to_xpath(selector, prefix,
-                                                 translate_pseudo_elements=True)
-                          for selector in parse(css))
+        return super(HTMLTranslator, self).css_to_xpath(css, prefix)
 
 _translator = HTMLTranslator()
 

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -1,3 +1,5 @@
+import functools
+
 from cssselect import GenericTranslator as OriginalGenericTranslator
 from cssselect import HTMLTranslator as OriginalHTMLTranslator
 from cssselect.xpath import XPathExpr as OriginalXPathExpr
@@ -100,7 +102,7 @@ class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
 
 _translator = HTMLTranslator()
 
-
+@functools.lru_cache(maxsize=128)
 def css2xpath(query):
     "Return translated XPath version of a given CSS query"
     return _translator.css_to_xpath(query)

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -1,6 +1,6 @@
-import sys
+import six
 
-if sys.version_info[0] < 3:
+if six.PY2:
     from functools32 import lru_cache
 else:
     from functools import lru_cache

--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -102,10 +102,12 @@ class GenericTranslator(TranslatorMixin, OriginalGenericTranslator):
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
         return super(GenericTranslator, self).css_to_xpath(css, prefix)
 
+
 class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
     @lru_cache(maxsize=256)
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
         return super(HTMLTranslator, self).css_to_xpath(css, prefix)
+
 
 _translator = HTMLTranslator()
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 
 import sys
 
-from setuptools import setup
+from pkg_resources import parse_version
+from setuptools import setup, __version__ as setuptools_version
 
 
 with open('README.rst') as readme_file:
@@ -15,15 +16,28 @@ with open('NEWS') as history_file:
 test_requirements = [
 ]
 
-INSTALL_REQUIRES = [
+def has_environment_marker_platform_impl_support():
+    """Code extracted from 'pytest/setup.py'
+    https://github.com/pytest-dev/pytest/blob/7538680c/setup.py#L31
+    The first known release to support environment marker with range operators
+    it is 18.5, see:
+    https://setuptools.readthedocs.io/en/latest/history.html#id235
+    """
+    return parse_version(setuptools_version) >= parse_version('18.5')
+
+install_requires = [
     'w3lib>=1.8.0',
     'lxml>=2.3',
     'six>=1.5.2',
     'cssselect>=0.9'
 ]
+extras_require = {}
 
-if sys.version_info[0:2] < (3, 0):
-    INSTALL_REQUIRES.append("functools32")
+if not has_environment_marker_platform_impl_support():
+    if sys.version_info[0:2] < (3, 0):
+        install_requires.append("functools32")
+else:
+    extras_require[":python_version<'3.0'"] = ["functools32"]
 
 setup(
     name='parsel',
@@ -39,7 +53,8 @@ setup(
     package_dir={'parsel':
                  'parsel'},
     include_package_data=True,
-    install_requires=INSTALL_REQUIRES,
+    install_requires=install_requires,
+    extras_require=extras_require,
     license="BSD",
     zip_safe=False,
     keywords='parsel',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 
 from setuptools import setup
 
@@ -13,6 +14,16 @@ with open('NEWS') as history_file:
 
 test_requirements = [
 ]
+
+INSTALL_REQUIRES = [
+    'w3lib>=1.8.0',
+    'lxml>=2.3',
+    'six>=1.5.2',
+    'cssselect>=0.9'
+]
+
+if sys.version_info[0:2] < (3, 0):
+    INSTALL_REQUIRES.append("functools32")
 
 setup(
     name='parsel',
@@ -28,12 +39,7 @@ setup(
     package_dir={'parsel':
                  'parsel'},
     include_package_data=True,
-    install_requires=[
-        'w3lib>=1.8.0',
-        'lxml>=2.3',
-        'six>=1.5.2',
-        'cssselect>=0.9',
-    ],
+    install_requires=INSTALL_REQUIRES,
     license="BSD",
     zip_safe=False,
     keywords='parsel',


### PR DESCRIPTION
@lopuhin , I am continuing the performance discuss from this [topic](https://github.com/scrapy/scrapy/issues/3133). I just tried added lru_cache to parse library func css to xpath and I am planning on testing it and give the data result. 
I am just wondering if it is correct to test the performance by creating a new virtualenv and test it with the benchmarker available in scrapy-bench, and how can I test it with the new version of the parsel that I created (I tried **python setup.py develop** in parsel after adding new code but it did not work)? Please let me know!