### PR TITLE
[MRG+1] Fix has-class to deal with newlines in class names

### DIFF
--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -3,6 +3,11 @@ from lxml import etree
 
 from six import string_types
 
+from w3lib.html import HTML5_WHITESPACE
+
+regex = '[{}]+'.format(HTML5_WHITESPACE)
+replace_html5_whitespaces = re.compile(regex).sub
+
 
 def set_xpathfunc(fname, func):
     """Register a custom extension function to use in XPath expressions.
@@ -49,7 +54,7 @@ def has_class(context, *classes):
     if node_cls is None:
         return False
     node_cls = ' ' + node_cls + ' '
-    node_cls = re.sub('\s+', ' ', node_cls)
+    node_cls = replace_html5_whitespaces(' ', node_cls)
     for cls in classes:
         if ' ' + cls + ' ' not in node_cls:
             return False

--- a/parsel/xpathfuncs.py
+++ b/parsel/xpathfuncs.py
@@ -1,3 +1,4 @@
+import re
 from lxml import etree
 
 from six import string_types
@@ -48,6 +49,7 @@ def has_class(context, *classes):
     if node_cls is None:
         return False
     node_cls = ' ' + node_cls + ' '
+    node_cls = re.sub('\s+', ' ', node_cls)
     for cls in classes:
         if ' ' + cls + ' ' not in node_cls:
             return False

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def has_environment_marker_platform_impl_support():
     return parse_version(setuptools_version) >= parse_version('18.5')
 
 install_requires = [
-    'w3lib>=1.8.0',
+    'w3lib>=1.19.0',
     'lxml>=2.3',
     'six>=1.5.2',
     'cssselect>=0.9'

--- a/tests/test_xpathfuncs.py
+++ b/tests/test_xpathfuncs.py
@@ -72,6 +72,25 @@ class XPathFuncsTestCase(unittest.TestCase):
             [x.extract() for x in sel.xpath('//p[has-class("foo")]/text()')],
             [u'First'])
 
+    def test_has_class_newline(self):
+        body = u"""
+        <p CLASS="foo
+        bar">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath(u'//p[has-class("foo")]/text()')],
+            [u'First'])
+
+    def test_has_class_tab(self):
+        body = u"""
+        <p CLASS="foo\tbar">First</p>
+        """
+        sel = Selector(text=body)
+        self.assertEqual(
+            [x.extract() for x in sel.xpath(u'//p[has-class("foo")]/text()')],
+            [u'First'])
+
     def test_set_xpathfunc(self):
 
         def myfunc(ctx):


### PR DESCRIPTION
The `has-class()` XPath function fails to select elements by class when there's a `\n` character right after the class name we're looking for. For example:

```python
>>> import parsel
>>> html = '''<p class="foo
bar">Hello</p>
'''
>>> parsel.Selector(text=html).xpath('//p[has-class("foo")]/text()').get() is None
True
```

Such (broken?) elements are not that uncommon around the web and they break `has-class` expected behavior (at least from my point of view).

Any thoughts on it?


