### PR TITLE
[WIP] Selector.text and SelectorList.text methods

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -150,6 +150,15 @@ class SelectorList(list):
         else:
             return {}
 
+    def text(self, clean_html=True, guess_punct_space=True, guess_layout=True,
+             sep='\n'):
+        return sep.join(
+            x.text(clean_html=clean_html,
+                   guess_punct_space=guess_punct_space,
+                   guess_layout=guess_layout)
+            for x in self
+        )
+
 
 class Selector(object):
     """
@@ -162,7 +171,7 @@ class Selector(object):
     If ``type`` is ``None``, the selector defaults to ``"html"``.
     """
 
-    __slots__ = ['text', 'namespaces', 'type', '_expr', 'root',
+    __slots__ = ['namespaces', 'type', '_expr', 'root',
                  '__weakref__', '_parser', '_csstranslator', '_tostring_method']
 
     _default_type = None
@@ -345,6 +354,20 @@ class Selector(object):
         """Return the attributes dictionary for underlying element.
         """
         return dict(self.root.attrib)
+
+    def text(self, clean_html=True, guess_punct_space=True, guess_layout=True):
+        from html_text.html_text import _clean_html, _html_to_text
+        tree = _clean_html(self.root) if clean_html else self.root
+        return _html_to_text(tree,
+                             guess_punct_space=guess_punct_space,
+                             guess_layout=guess_layout)
+
+    # def cleaned(self):
+    #     from html_text.html_text import _clean_html
+    #     root = _clean_html(self.root)
+    #     return self.__class__(root=root, _expr=self._expr,
+    #                           namespaces=self.namespaces,
+    #                           type=self.type)
 
     def __bool__(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_requires = [
     'w3lib>=1.19.0',
     'lxml>=2.3',
     'six>=1.5.2',
-    'cssselect>=0.9'
+    'cssselect>=0.9',
+    'html-text>=0.4.1',
 ]
 extras_require = {}
 


### PR DESCRIPTION
I've opened it for a discussion, it is not a complete solution. See https://github.com/scrapy/parsel/pull/34 for original proposal.

Here `.text()` methods are added for Selector and SelectorList, using https://github.com/TeamHG-Memex/html-text library.

Problems:

1. Naming issue. In scrapy it can be convenient to have `response.text()` shortcut, to use it instead of `response.css('body').text()` or `response.selector.text()`. But we already have response.text, which is unicode body. It makes this feature more confusing - selector's .text() methods are very different from response.text attribute. From this point of view, .text_content() name sounds better. Any ideas for a shorter / alternative name?

2. There is a circular package dependency: html_text requires parsel, and parsel requires html_text. This is not a problem code-wise, but I haven't checked how well pip can handle it. In a basic case it seems to work, but I wonder if we get issues related to this. It can be solved by changing html_text API.

3. parsel imports private html_text methods. This can be solved by changing html_text API.

4. Cleaning is called for each Selector.text() call. So e.g. in case of `sel.css('div').text()` each div will be cleaned and copied - instead of cleaning a tree once. I'm not sure how large is this problem tough; probably it is inefficient when you need to extract text from nested elements (e.g. from all elements) - it means cleaning will be run multiple times on same parts of the tree. Alternative solution is to have `sel.cleaned().text()` or something like this; `.cleaned()` may allow lxml Cleaner arguments. But it looks like a separate feature; also, Cleaner parameters which work best with html-text are not default.

5. When user requests sel.text() from an element which is removed by Cleaner (e.g. `sel.css('script')[0].text()`, None is returned. Should it be an empty string?

6. SelectorList.text() joins text. This is similar to what's proposed in https://github.com/scrapy/scrapy/pull/772, but different from SelectorList.get, which returns the first element. If needed, we can support both behaviors, by using sep=None by default (or join=None if we rename 'sep' argument to 'join'), meaning "don't join, take first" - or would it be too confusing?
