### PR TITLE
Remove Selectors or SelectorLists from their parent elements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Features
 --------
 
 * Extract text using CSS or XPath selectors
+* Remove elements using CSS or XPath selectors
 * Regular expression helper methods
 
 Example::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -385,6 +385,37 @@ XPath specification.
 .. _Location Paths: https://www.w3.org/TR/xpath#location-paths
 
 
+Removing elements
+-----------------
+
+If for any reason you need to remove elements based on a Selector or
+a SelectorList, you can do it with the ``remove()`` method, available for both
+classes.
+
+Example removing an ad from a blog post:
+
+    >>> from parsel import Selector
+    >>> doc = u"""
+    ... <article>
+    ...     <div class="row">Content paragraph...</div>
+    ...     <div class="row">
+    ...         <div class="ad">
+    ...             Ad content...
+    ...             <a href="http://...">Link</a>
+    ...         </div>
+    ...     </div>
+    ...     <div class="row">More content...</div>
+    ... </article>
+    ... """
+    >>> sel = Selector(text=doc)
+    >>> sel.xpath('//div/text()').getall()
+    ['Content paragraph...', 'Ad content...', 'Link', 'More content...']
+    >>> sel.xpath('//div[@class="ad"]').remove()
+    >>> sel.xpath('//div//text()').getall()
+    ['Content paragraph...', 'More content...']
+    >>>
+
+
 Using EXSLT extensions
 ----------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -392,6 +392,10 @@ If for any reason you need to remove elements based on a Selector or
 a SelectorList, you can do it with the ``remove()`` method, available for both
 classes.
 
+.. warning:: this is a destructive action and cannot be undone. The original
+    content of the selector is removed from the elements tree. This could be useful
+    when trying to reduce the memory footprint of Responses.
+
 Example removing an ad from a blog post:
 
     >>> from parsel import Selector

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -150,6 +150,13 @@ class SelectorList(list):
         else:
             return {}
 
+    def remove(self):
+        """
+        Remove matched nodes from the parent for each element in this list.
+        """
+        for x in self:
+            x.remove()
+
 
 class Selector(object):
     """
@@ -341,6 +348,12 @@ class Selector(object):
                     el.attrib[an.split('}', 1)[1]] = el.attrib.pop(an)
         # remove namespace declarations
         etree.cleanup_namespaces(self.root)
+
+    def remove(self):
+        """
+        Remove matched nodes from the parent element.
+        """
+        self.root.getparent().remove(self.root)
 
     @property
     def attrib(self):

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -12,12 +12,10 @@ from .csstranslator import HTMLTranslator, GenericTranslator
 
 
 class CannotRemovePseudoElement(Exception):
-
     pass
 
 
 class CannotRemoveRootElement(Exception):
-
     pass
 
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -15,7 +15,7 @@ class CannotRemoveElementWithoutRoot(Exception):
     pass
 
 
-class CannotRemoveRootElement(Exception):
+class CannotRemoveElementWithoutParent(Exception):
     pass
 
 
@@ -376,7 +376,7 @@ class Selector(object):
             parent.remove(self.root)
         except AttributeError:
             # 'NoneType' object has no attribute 'remove'
-            raise CannotRemoveRootElement(
+            raise CannotRemoveElementWithoutParent(
                 "The node you're trying to remove has no parent, "
                 "are you trying to remove a root element?"
             )

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -11,7 +11,12 @@ from .utils import flatten, iflatten, extract_regex, shorten
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
-class InvalidSelectorError(Exception):
+class CannotRemovePseudoElement(Exception):
+
+    pass
+
+
+class CannotRemoveRootElement(Exception):
 
     pass
 
@@ -361,13 +366,21 @@ class Selector(object):
         try:
             parent = self.root.getparent()
         except AttributeError:
-            raise InvalidSelectorError(
-                "The specified selector does not have a parent and could not be removed. "
-                "Make sure you're using a proper tag selector. "
-                "Try to use 'li' instead of 'li::text', for example."
+            # 'str' object has no attribute 'getparent'
+            raise CannotRemovePseudoElement(
+                "The node you're trying to remove might be a pseudo-element, "
+                "try to use 'li' as a selector instead of 'li::text' or "
+                "'//li' instead of '//li/text()', for example."
             )
 
-        parent.remove(self.root)
+        try:
+            parent.remove(self.root)
+        except AttributeError:
+            # 'NoneType' object has no attribute 'remove'
+            raise CannotRemoveRootElement(
+                "The node you're trying to remove has no parent, "
+                "are you trying to remove a root element?"
+            )
 
     @property
     def attrib(self):

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -11,6 +11,11 @@ from .utils import flatten, iflatten, extract_regex, shorten
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
+class InvalidSelectorError(Exception):
+
+    pass
+
+
 class SafeXMLParser(etree.XMLParser):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('resolve_entities', False)
@@ -353,7 +358,16 @@ class Selector(object):
         """
         Remove matched nodes from the parent element.
         """
-        self.root.getparent().remove(self.root)
+        try:
+            parent = self.root.getparent()
+        except AttributeError:
+            raise InvalidSelectorError(
+                "The specified selector does not have a parent and could not be removed. "
+                "Make sure you're using a proper tag selector. "
+                "Try to use 'li' instead of 'li::text', for example."
+            )
+
+        parent.remove(self.root)
 
     @property
     def attrib(self):

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -11,7 +11,7 @@ from .utils import flatten, iflatten, extract_regex, shorten
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
-class CannotRemovePseudoElement(Exception):
+class CannotRemoveElementWithoutRoot(Exception):
     pass
 
 
@@ -365,9 +365,10 @@ class Selector(object):
             parent = self.root.getparent()
         except AttributeError:
             # 'str' object has no attribute 'getparent'
-            raise CannotRemovePseudoElement(
-                "The node you're trying to remove might be a pseudo-element, "
-                "try to use 'li' as a selector instead of 'li::text' or "
+            raise CannotRemoveElementWithoutRoot(
+                "The node you're trying to remove has no root, "
+                "are you trying to remove a pseudo-element? "
+                "Try to use 'li' as a selector instead of 'li::text' or "
                 "'//li' instead of '//li/text()', for example."
             )
 

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -6,6 +6,7 @@ import unittest
 import pickle
 
 from parsel import Selector
+from parsel.selector import InvalidSelectorError
 
 
 class SelectorTestCase(unittest.TestCase):
@@ -758,6 +759,26 @@ class SelectorTestCase(unittest.TestCase):
         sel_list[0].remove()
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
         self.assertEqual(sel.css('li::text').getall(), ['2', '3'])
+
+    def test_remove_invalid_selector_list(self):
+        sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+        sel_list = sel.css('li::text')
+        self.assertEqual(sel_list.getall(), ['1', '2', '3'])
+        with self.assertRaises(InvalidSelectorError):
+            sel_list.remove()
+
+        self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
+        self.assertEqual(sel.css('li::text').getall(), ['1', '2', '3'])
+
+    def test_remove_invalid_selector(self):
+        sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+        sel_list = sel.css('li::text')
+        self.assertEqual(sel_list.getall(), ['1', '2', '3'])
+        with self.assertRaises(InvalidSelectorError):
+            sel_list[0].remove()
+
+        self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
+        self.assertEqual(sel.css('li::text').getall(), ['1', '2', '3'])
 
 
 class ExsltTestCase(unittest.TestCase):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -6,7 +6,10 @@ import unittest
 import pickle
 
 from parsel import Selector
-from parsel.selector import InvalidSelectorError
+from parsel.selector import (
+    CannotRemovePseudoElement,
+    CannotRemoveRootElement,
+)
 
 
 class SelectorTestCase(unittest.TestCase):
@@ -760,25 +763,41 @@ class SelectorTestCase(unittest.TestCase):
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
         self.assertEqual(sel.css('li::text').getall(), ['2', '3'])
 
-    def test_remove_invalid_selector_list(self):
+    def test_remove_pseudo_element_selector_list(self):
         sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
         sel_list = sel.css('li::text')
         self.assertEqual(sel_list.getall(), ['1', '2', '3'])
-        with self.assertRaises(InvalidSelectorError):
+        with self.assertRaises(CannotRemovePseudoElement):
             sel_list.remove()
 
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
         self.assertEqual(sel.css('li::text').getall(), ['1', '2', '3'])
 
-    def test_remove_invalid_selector(self):
+    def test_remove_pseudo_element_selector(self):
         sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
         sel_list = sel.css('li::text')
         self.assertEqual(sel_list.getall(), ['1', '2', '3'])
-        with self.assertRaises(InvalidSelectorError):
+        with self.assertRaises(CannotRemovePseudoElement):
             sel_list[0].remove()
 
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
         self.assertEqual(sel.css('li::text').getall(), ['1', '2', '3'])
+
+    def test_remove_root_element_selector(self):
+        sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+        sel_list = sel.css('li::text')
+        self.assertEqual(sel_list.getall(), ['1', '2', '3'])
+        with self.assertRaises(CannotRemoveRootElement):
+            sel.remove()
+
+        with self.assertRaises(CannotRemoveRootElement):
+            sel.css('html').remove()
+
+        self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
+        self.assertEqual(sel.css('li::text').getall(), ['1', '2', '3'])
+
+        sel.css('body').remove()
+        self.assertEqual(sel.get(), '<html></html>')
 
 
 class ExsltTestCase(unittest.TestCase):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -745,6 +745,21 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(u'<html><body><p>Grainy</p></body></html>',
                           self.sscls(text).extract())
 
+    def test_remove_selector_list(self):
+        sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+        sel_list = sel.css('li')
+        sel_list.remove()
+        self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
+        self.assertEqual(sel.css('li'), [])
+
+    def test_remove_selector(self):
+        sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+        sel_list = sel.css('li')
+        sel_list[0].remove()
+        self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
+        self.assertEqual(sel.css('li::text').getall(), ['2', '3'])
+
+
 class ExsltTestCase(unittest.TestCase):
 
     sscls = Selector

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -7,7 +7,7 @@ import pickle
 
 from parsel import Selector
 from parsel.selector import (
-    CannotRemovePseudoElement,
+    CannotRemoveElementWithoutRoot,
     CannotRemoveRootElement,
 )
 
@@ -767,7 +767,7 @@ class SelectorTestCase(unittest.TestCase):
         sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
         sel_list = sel.css('li::text')
         self.assertEqual(sel_list.getall(), ['1', '2', '3'])
-        with self.assertRaises(CannotRemovePseudoElement):
+        with self.assertRaises(CannotRemoveElementWithoutRoot):
             sel_list.remove()
 
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)
@@ -777,7 +777,7 @@ class SelectorTestCase(unittest.TestCase):
         sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
         sel_list = sel.css('li::text')
         self.assertEqual(sel_list.getall(), ['1', '2', '3'])
-        with self.assertRaises(CannotRemovePseudoElement):
+        with self.assertRaises(CannotRemoveElementWithoutRoot):
             sel_list[0].remove()
 
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -8,7 +8,7 @@ import pickle
 from parsel import Selector
 from parsel.selector import (
     CannotRemoveElementWithoutRoot,
-    CannotRemoveRootElement,
+    CannotRemoveElementWithoutParent,
 )
 
 
@@ -787,10 +787,10 @@ class SelectorTestCase(unittest.TestCase):
         sel = self.sscls(text=u'<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
         sel_list = sel.css('li::text')
         self.assertEqual(sel_list.getall(), ['1', '2', '3'])
-        with self.assertRaises(CannotRemoveRootElement):
+        with self.assertRaises(CannotRemoveElementWithoutParent):
             sel.remove()
 
-        with self.assertRaises(CannotRemoveRootElement):
+        with self.assertRaises(CannotRemoveElementWithoutParent):
             sel.css('html').remove()
 
         self.assertIsInstance(sel.css('li'), self.sscls.selectorlist_cls)


### PR DESCRIPTION
This could be helpful in some cases when it's easier to get rid of the bad content than to write complex selectors.