### PR TITLE
[MRG+1] Embed cssselect reference

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -258,6 +258,8 @@ class Selector(object):
 
         In the background, CSS queries are translated into XPath queries using
         `cssselect`_ library and run ``.xpath()`` method.
+        
+        .. _cssselect: https://pypi.python.org/pypi/cssselect/
         """
         return self.xpath(self._css2xpath(query))
 


### PR DESCRIPTION
Include `.. _cssselect: https://pypi.python.org/pypi/cssselect/` in the source code comments where it is used.

While not necessary for the Parsel documentation itself (because the documentation page including this comment has this reference already at the bottom), it allows other projects inheriting documentation from Parsel (e.g. Scrapy’s Selector class) to inherit this documentation without missing the reference URL (`…/scrapy/scrapy/selector/unified.py:docstring of scrapy.Selector.css:5: WARNING: Unknown target name: "cssselect".`).