### PR TITLE
Add HTML5Parser option

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -44,12 +44,18 @@ def create_root_node(text, parser_cls, base_url=None):
     """Create root node for text using given parser class.
     """
     body = text.strip().replace('\x00', '').encode('utf8') or b'<html/>'
-    if parser_cls != html5parser.HTMLParser:
+    root = None
+    if parser_cls == html5parser.HTMLParser:
+        try:
+            parser = parser_cls(namespaceHTMLElements=False)
+            root = parser.parse(body, useChardet=False, override_encoding='utf8').getroot()
+        except ValueError:
+            # In case that's not possible to parse with html5parser change to normal htmlparser
+            parser = html.HTMLParser(recover=True, encoding='utf8')
+            root = etree.fromstring(body, parser=parser, base_url=base_url)
+    else:
         parser = parser_cls(recover=True, encoding='utf8')
         root = etree.fromstring(body, parser=parser, base_url=base_url)
-    else:
-        parser = parser_cls(namespaceHTMLElements=False)
-        root = html5parser.fromstring(body, parser=parser)
     if root is None:
         root = etree.fromstring(b'<html/>', parser=parser, base_url=base_url)
     return root

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -44,15 +44,12 @@ def create_root_node(text, parser_cls, base_url=None):
     """Create root node for text using given parser class.
     """
     body = text.strip().replace('\x00', '').encode('utf8') or b'<html/>'
-    root = None
     if parser_cls == html5parser.HTMLParser:
         try:
             parser = parser_cls(namespaceHTMLElements=False)
             root = parser.parse(body, useChardet=False, override_encoding='utf8').getroot()
         except ValueError:
-            # In case that's not possible to parse with html5parser change to normal htmlparser
-            parser = html.HTMLParser(recover=True, encoding='utf8')
-            root = etree.fromstring(body, parser=parser, base_url=base_url)
+            raise TypeError('HTML5parser does not support control characters')
     else:
         parser = parser_cls(recover=True, encoding='utf8')
         root = etree.fromstring(body, parser=parser, base_url=base_url)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_requires = [
     'w3lib>=1.19.0',
     'lxml>=2.3',
     'six>=1.5.2',
-    'cssselect>=0.9'
+    'cssselect>=0.9',
+    'html5lib',
 ]
 extras_require = {}
 

--- a/tests/html_parser.json
+++ b/tests/html_parser.json
@@ -1,0 +1,4 @@
+{
+  "html_parser": "html",
+  "html5_parser": "html5"
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+ddt

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -786,6 +786,13 @@ class SelectorTestCase(unittest.TestCase):
         res = sel.xpath('//div').get()
         self.assertEqual(res, expected)
 
+    def test_control_characters(self):
+        """HTML5parser can't parse sequence characters."""
+        body = u'<p id="\x01">'
+        self.assertRaisesRegexp(TypeError, 'HTML5parser does not support control characters',
+                                self.sscls, body, 'html5')
+
+
 @ddt
 class ExsltTestCase(unittest.TestCase):
     sscls = Selector

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -498,7 +498,7 @@ class SelectorTestCase(unittest.TestCase):
                          ["John", "Paul"])
         self.assertEqual(x.xpath("//ul/li").re(r"Age: (\d+)"),
                          ["10", "20"])
-        
+
         # Test named group, hit and miss
         x = self.sscls(text=u'foobar')
         self.assertEqual(x.re('(?P<extract>foo)'), ['foo'])
@@ -511,7 +511,7 @@ class SelectorTestCase(unittest.TestCase):
     def test_re_replace_entities(self):
         body = u"""<script>{"foo":"bar &amp; &quot;baz&quot;"}</script>"""
         x = self.sscls(text=body)
-        
+
         name_re = re.compile('{"foo":(.*)}')
 
         # by default, only &amp; and &lt; are preserved ;
@@ -711,6 +711,39 @@ class SelectorTestCase(unittest.TestCase):
         text = u'<html>\x00<body><p>Grainy</p></body></html>'
         self.assertEqual(u'<html><body><p>Grainy</p></body></html>',
                           self.sscls(text).extract())
+
+    def test_characters_gt_and_lt(self):
+        """HTML5 parser tests: greater and less than symbols work as expected."""
+        lt_elem = '20 < 100'
+        gt_elem = '120 > 100'
+        body = u'''<html>
+                    <head></head>
+                    <body>
+                     <div id="distance">{0}</div>
+                    <body>
+                </html>'''
+
+        sel = self.sscls(text=body.format(lt_elem), type='html5')
+        lt_res = sel.xpath('//div[@id="distance"]/text()').get()
+        self.assertEqual(lt_res, lt_elem, msg='less than(<) parsing does not work as expected')
+
+        sel = self.sscls(text=body.format(gt_elem), type='html5')
+        gt_res = sel.xpath('//div[@id="distance"]/text()').get()
+        self.assertEqual(gt_res, gt_elem, msg='greater than(>) parsing does not work as expected')
+
+    def test_complete_tags(self):
+        """HTML5 parser complete/fill tags as expected."""
+        body = u'''<html>
+                    <head></head>
+                       <body>
+                        <li>one<div></li>
+                        <li>two</li>
+                       </body>
+                </html>'''
+        sel = self.sscls(text=body, type='html5')
+        res = sel.xpath('//div/text()').get()
+        self.assertEqual(res, None)
+
 
 class ExsltTestCase(unittest.TestCase):
 


### PR DESCRIPTION
PR Solves Issue #83.
As that issue pointed out, there's a lot of requests to add this option: [1](https://github.com/scrapy/scrapy/issues/2205) [2](https://github.com/scrapy/parsel/issues/57) [3](https://github.com/scrapy/scrapy/issues/1858) [4](https://github.com/scrapy/scrapy/issues/2730) [5](https://github.com/scrapy/parsel/pull/54#issuecomment-323665165) [6](https://github.com/scrapy/scrapy/issues/1039)

Based/Continue work of https://github.com/scrapy/parsel/pull/54 & https://github.com/scrapy/scrapy/pull/1043

Known issues with `html5lib`:
https://github.com/html5lib/html5lib-python/issues/96 , for now I just raise a TypeError, is there another/better way to handle this?


I also made some benchmarks, and I obtain that `html5lib` is a waaaaay slower than normal `html` parser. It's `60` times  slower when parse: https://gist.github.com/joaquingx/efaf1152beb4e4ea25d6a8afa061ebcf (I used https://gist.github.com/kmike/af647777cef39c3d01071905d176c006 as reference). Due that, should be a good idea to make some alert when user chooses `html5` as option?