### PR TITLE
[MRG+1] Selector.remove_namespaces: call etree.cleanup_namespaces only once

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -339,8 +339,8 @@ class Selector(object):
             for an in el.attrib.keys():
                 if an.startswith('{'):
                     el.attrib[an.split('}', 1)[1]] = el.attrib.pop(an)
-            # remove namespace declarations
-            etree.cleanup_namespaces(self.root)
+        # remove namespace declarations
+        etree.cleanup_namespaces(self.root)
 
     @property
     def attrib(self):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -639,6 +639,33 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(len(sel.xpath("//link")), 3)
         self.assertEqual(len(sel.xpath("./namespace::*")), 1)
 
+    def test_remove_namespaces_embedded(self):
+        xml = u"""
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <link type="text/html"/>
+          <entry>
+            <link type="text/html"/>
+          </entry>
+          <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100">
+            <linearGradient id="gradient">
+              <stop class="begin" offset="0%" style="stop-color:yellow;"/>
+              <stop class="end" offset="80%" style="stop-color:green;"/>
+            </linearGradient>
+            <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
+          </svg>
+        </feed>
+        """
+        sel = self.sscls(text=xml, type='xml')
+        self.assertEqual(len(sel.xpath("//link")), 0)
+        self.assertEqual(len(sel.xpath("//stop")), 0)
+        self.assertEqual(len(sel.xpath("./namespace::*")), 2)
+        self.assertEqual(len(sel.xpath("//f:link", namespaces={'f': 'http://www.w3.org/2005/Atom'})), 2)
+        self.assertEqual(len(sel.xpath("//s:stop", namespaces={'s': 'http://www.w3.org/2000/svg'})), 2)
+        sel.remove_namespaces()
+        self.assertEqual(len(sel.xpath("//link")), 2)
+        self.assertEqual(len(sel.xpath("//stop")), 2)
+        self.assertEqual(len(sel.xpath("./namespace::*")), 1)
+
     def test_remove_attributes_namespaces(self):
         xml = u"""<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns:atom="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -625,28 +625,34 @@ class SelectorTestCase(unittest.TestCase):
     def test_remove_namespaces(self):
         xml = u"""<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">
-  <link type="text/html">
-  <link type="application/atom+xml">
+  <link type="text/html"/>
+  <entry>
+    <link type="text/html"/>
+  </entry>
+  <link type="application/atom+xml"/>
 </feed>
 """
         sel = self.sscls(text=xml, type='xml')
         self.assertEqual(len(sel.xpath("//link")), 0)
         self.assertEqual(len(sel.xpath("./namespace::*")), 3)
         sel.remove_namespaces()
-        self.assertEqual(len(sel.xpath("//link")), 2)
+        self.assertEqual(len(sel.xpath("//link")), 3)
         self.assertEqual(len(sel.xpath("./namespace::*")), 1)
 
     def test_remove_attributes_namespaces(self):
         xml = u"""<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns:atom="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">
-  <link atom:type="text/html">
-  <link atom:type="application/atom+xml">
+  <link atom:type="text/html"/>
+  <entry>
+    <link atom:type="text/html"/>
+  </entry>
+  <link atom:type="application/atom+xml"/>
 </feed>
 """
         sel = self.sscls(text=xml, type='xml')
         self.assertEqual(len(sel.xpath("//link/@type")), 0)
         sel.remove_namespaces()
-        self.assertEqual(len(sel.xpath("//link/@type")), 2)
+        self.assertEqual(len(sel.xpath("//link/@type")), 3)
 
     def test_smart_strings(self):
         """Lxml smart strings return values"""


### PR DESCRIPTION
https://github.com/scrapy/scrapy/issues/3832 got me thinking. My reasoning was that if removing namespaces involves iterating over all nodes, it should _at most_ take (roughly) the same amount of time it takes for an operation that processes all nodes, thus making said operation take twice as long and not 20 min vs. 2/3 days (my reason is a fragile thing, so my reasoning could easily be wrong :smile:).
So I took a look at the `Selector.remove_namespaces` method and found that the `lxml.etree.cleanup_namespaces` function is called for each node in the iteration, but I think according to [its documentation](https://lxml.de/api/lxml.etree-module.html#cleanup_namespaces) it should only be needed once.
I ran a small benchmark, and while the change is not as big as I expected (so I might be missing something here!), there is an improvement nonetheless.

Looking forward to reading your comments!

```python
In [1]: import parsel
   ...: links = """<link type="text/html"/>
   ...: <link type="application/atom+xml"/>
   ...: """
   ...: xml = """<?xml version="1.0" encoding="UTF-8"?>
   ...: <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US" xmlns:media="http://search.yahoo.com/mrss/">
   ...: {links}
   ...: </feed>
   ...: """.format(links=links*5000)
   ...: def remove():
   ...:     sel = parsel.Selector(text=xml, type='xml')
   ...:     sel.remove_namespaces()
   ...:

In [2]: %timeit remove()
5.47 s ± 1.14 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: from importlib import reload
   ...: reload(parsel)  # after reducing indentation level
Out[3]: <module 'parsel' from '/.../parsel/parsel/__init__.py'>

In [4]: %timeit remove()
4.57 s ± 692 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```