### PR TITLE
Shorten selector representations using an ellipsis

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -7,7 +7,7 @@ import sys
 import six
 from lxml import etree, html
 
-from .utils import flatten, iflatten, extract_regex
+from .utils import flatten, iflatten, extract_regex, selector_data_shorten
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
@@ -358,6 +358,6 @@ class Selector(object):
     __nonzero__ = __bool__
 
     def __str__(self):
-        data = repr(self.get()[:40])
+        data = repr(selector_data_shorten(self.get(), width=40))
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
     __repr__ = __str__

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -7,7 +7,7 @@ import sys
 import six
 from lxml import etree, html
 
-from .utils import flatten, iflatten, extract_regex, shorten_selector_data
+from .utils import flatten, iflatten, extract_regex, shorten
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
@@ -358,6 +358,6 @@ class Selector(object):
     __nonzero__ = __bool__
 
     def __str__(self):
-        data = repr(shorten_selector_data(self.get(), width=40))
+        data = repr(shorten(self.get(), width=40))
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
     __repr__ = __str__

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -7,7 +7,7 @@ import sys
 import six
 from lxml import etree, html
 
-from .utils import flatten, iflatten, extract_regex, selector_data_shorten
+from .utils import flatten, iflatten, extract_regex, shorten_selector_data
 from .csstranslator import HTMLTranslator, GenericTranslator
 
 
@@ -358,6 +358,6 @@ class Selector(object):
     __nonzero__ = __bool__
 
     def __str__(self):
-        data = repr(selector_data_shorten(self.get(), width=40))
+        data = repr(shorten_selector_data(self.get(), width=40))
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
     __repr__ = __str__

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -82,7 +82,13 @@ def extract_regex(regex, text, replace_entities=True):
         return strings
     return [w3lib_replace_entities(s, keep=['lt', 'amp']) for s in strings]
 
-def shorten_selector_data(data, width):
-    """Shortens the preview of extracted data by adding placeholder '...'
-    """
-    return data[:width - 3] + "..." if (len(data) > width - 3) else data
+
+def shorten(text, width, suffix='...'):
+    """Truncate the given text to fit in the given width."""
+    if len(text) <= width:
+        return text
+    if width > len(suffix):
+        return text[:width-len(suffix)] + suffix
+    if width >= 0:
+        return suffix[len(suffix)-width:]
+    raise ValueError('width must be equal or greater than 0')

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -1,5 +1,6 @@
 import re
 import six
+import textwrap
 from w3lib.html import replace_entities as w3lib_replace_entities
 
 
@@ -81,3 +82,10 @@ def extract_regex(regex, text, replace_entities=True):
     if not replace_entities:
         return strings
     return [w3lib_replace_entities(s, keep=['lt', 'amp']) for s in strings]
+
+def selector_data_shorten(data, width):
+    """Shortens the preview of extracted data by adding placeholder '...'
+    """
+    if six.PY2:
+        return data[:40]
+    return textwrap.shorten(data, width=width, placeholder="...")

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -86,6 +86,7 @@ def extract_regex(regex, text, replace_entities=True):
 def selector_data_shorten(data, width):
     """Shortens the preview of extracted data by adding placeholder '...'
     """
-    if six.PY2:
+    if six.PY34:
+        return textwrap.shorten(data, width=width, placeholder="...")
+    else:
         return data[:40]
-    return textwrap.shorten(data, width=width, placeholder="...")

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -1,6 +1,5 @@
 import re
 import six
-import textwrap
 from w3lib.html import replace_entities as w3lib_replace_entities
 
 
@@ -83,10 +82,7 @@ def extract_regex(regex, text, replace_entities=True):
         return strings
     return [w3lib_replace_entities(s, keep=['lt', 'amp']) for s in strings]
 
-def selector_data_shorten(data, width):
+def shorten_selector_data(data, width):
     """Shortens the preview of extracted data by adding placeholder '...'
     """
-    if six.PY34:
-        return textwrap.shorten(data, width=width, placeholder="...")
-    else:
-        return data[:40]
+    return data[:width - 3] + "..." if (len(data) > width - 3) else data

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -133,9 +133,12 @@ class SelectorTestCase(unittest.TestCase):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')
         sel = self.sscls(text=body)
 
-        representation = "<Selector xpath='//input/@name' data='{}'>".format('...')
         if six.PY2:
             representation = "<Selector xpath='//input/@name' data=u'{}'>".format(40 * 'b')
+        elif six.PY34:
+            representation = "<Selector xpath='//input/@name' data='{}'>".format('...')
+        else:
+            representation = "<Selector xpath='//input/@name' data='{}'>".format(40 * 'b')
 
         self.assertEqual(
             [repr(it) for it in sel.xpath('//input/@name')],

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -133,12 +133,9 @@ class SelectorTestCase(unittest.TestCase):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')
         sel = self.sscls(text=body)
 
+        representation = "<Selector xpath='//input/@name' data='{}...'>".format(37 * 'b')
         if six.PY2:
-            representation = "<Selector xpath='//input/@name' data=u'{}'>".format(40 * 'b')
-        elif six.PY34:
-            representation = "<Selector xpath='//input/@name' data='{}'>".format('...')
-        else:
-            representation = "<Selector xpath='//input/@name' data='{}'>".format(40 * 'b')
+            representation = "<Selector xpath='//input/@name' data=u'{}...'>".format(37 * 'b')
 
         self.assertEqual(
             [repr(it) for it in sel.xpath('//input/@name')],

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -133,7 +133,7 @@ class SelectorTestCase(unittest.TestCase):
         body = u"<p><input name='{}' value='\xa9'/></p>".format(50 * 'b')
         sel = self.sscls(text=body)
 
-        representation = "<Selector xpath='//input/@name' data='{}'>".format(40 * 'b')
+        representation = "<Selector xpath='//input/@name' data='{}'>".format('...')
         if six.PY2:
             representation = "<Selector xpath='//input/@name' data=u'{}'>".format(40 * 'b')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+from parsel.utils import shorten
+
+from pytest import mark, raises
+import six
+
+
+@mark.parametrize(
+    'width,expected',
+    (
+        (-1, ValueError),
+        (0, u''),
+        (1, u'.'),
+        (2, u'..'),
+        (3, u'...'),
+        (4, u'f...'),
+        (5, u'fo...'),
+        (6, u'foobar'),
+        (7, u'foobar'),
+    )
+)
+def test_shorten(width, expected):
+    if isinstance(expected, six.string_types):
+        assert shorten(u'foobar', width) == expected
+    else:
+        with raises(expected):
+            shorten(u'foobar', width)


### PR DESCRIPTION
Fork of #95 based on the feedback there by @kmike that never got an answer.

Fixes #91.

My Unicode heart asked me for using a single ellipsis character (…) in Python 3, but I guess having a consistent behavior across Python versions is preferred :slightly_smiling_face: 

I used a regular test function instead of doctests to test a wide array of scenarios without making the documentation too noisy.

I feel like the implementation is overkill. I blame the tests.