### PR TITLE
better error message when incorrect data is passed to Selector "text" argument

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -189,7 +189,9 @@ class Selector(object):
 
         if text is not None:
             if not isinstance(text, six.text_type):
-                raise TypeError("text argument should be of type %s" % six.text_type)
+                msg = "text argument should be of type %s, got %s" % (
+                           six.text_type, text.__class__)
+                raise TypeError(msg)
             root = self._get_root(text, base_url)
         elif root is None:
             raise ValueError("Selector needs either text or root argument")


### PR DESCRIPTION
Selector(12) error message:

before:

```
TypeError: text argument should be of type <class 'str'>
```

after:

```
TypeError: text argument should be of type <class 'str'>, got <class 'int'>
```