### PR TITLE
Add explanation for argument 'base_url'

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -173,7 +173,8 @@ class Selector(object):
     ``type`` defines the selector type, it can be ``"html"``, ``"xml"`` or ``None`` (default).
     If ``type`` is ``None``, the selector defaults to ``"html"``.
 
-    The ``base_url`` keyword allows setting a URL for the document. This is needed when looking up external entities with relative paths. See [`lxml` documentation](https://lxml.de/api/index.html) for more information.
+    The ``base_url`` keyword allows setting a URL for the document. This is needed when looking up external entities with relative paths.
+    See [`lxml` documentation](https://lxml.de/api/index.html) for more information.
     """
 
     __slots__ = ['text', 'namespaces', 'type', '_expr', 'root',

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -174,7 +174,7 @@ class Selector(object):
     If ``type`` is ``None``, the selector defaults to ``"html"``.
 
     The ``base_url`` keyword allows setting a URL for the document. This is needed when looking up external entities with relative paths.
-    See [`lxml` documentation](https://lxml.de/api/index.html) for more information.
+    See [`lxml` documentation](https://lxml.de/api/index.html) ``lxml.etree.fromstring`` for more information.
     """
 
     __slots__ = ['text', 'namespaces', 'type', '_expr', 'root',

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -172,6 +172,8 @@ class Selector(object):
 
     ``type`` defines the selector type, it can be ``"html"``, ``"xml"`` or ``None`` (default).
     If ``type`` is ``None``, the selector defaults to ``"html"``.
+
+    The ``base_url`` keyword allows setting a URL for the document. This is needed when looking up external entities with relative paths. See [`lxml` documentation](https://lxml.de/api/index.html) for more information.
     """
 
     __slots__ = ['text', 'namespaces', 'type', '_expr', 'root',

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -173,7 +173,7 @@ class Selector(object):
     ``type`` defines the selector type, it can be ``"html"``, ``"xml"`` or ``None`` (default).
     If ``type`` is ``None``, the selector defaults to ``"html"``.
 
-    The ``base_url`` keyword allows setting a URL for the document. This is needed when looking up external entities with relative paths.
+    ``base_url`` allows setting a URL for the document. This is needed when looking up external entities with relative paths.
     See [`lxml` documentation](https://lxml.de/api/index.html) ``lxml.etree.fromstring`` for more information.
     """
 


### PR DESCRIPTION
I found that there was hardly any explanation for the argument 'base_url', which is eventually passed to lxml.etree.fromstring as a base URL for the current page, useful when we need to access relevant pages or resources via relative paths. This argument is not quite important for newcomers but I think it's inappropriate to ignore it in the doc. 
I added a simple explanation about it into the script and provided a link to lxml api reference, which may be helpful for those who are interested in the source code.