### PR TITLE
GenericTranslator, HTMLTranslator: override xpath_pseudo_element to…

### DIFF
--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -98,15 +98,25 @@ class TranslatorMixin(object):
 
 
 class GenericTranslator(TranslatorMixin, OriginalGenericTranslator):
+
     @lru_cache(maxsize=256)
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
         return super(GenericTranslator, self).css_to_xpath(css, prefix)
 
+    def xpath_pseudo_element(self, xpath, pseudo_element):
+        return TranslatorMixin.xpath_pseudo_element(
+            self, xpath, pseudo_element)
+
 
 class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
+
     @lru_cache(maxsize=256)
     def css_to_xpath(self, css, prefix='descendant-or-self::'):
         return super(HTMLTranslator, self).css_to_xpath(css, prefix)
+
+    def xpath_pseudo_element(self, xpath, pseudo_element):
+        return TranslatorMixin.xpath_pseudo_element(
+            self, xpath, pseudo_element)
 
 
 _translator = HTMLTranslator()


### PR DESCRIPTION
…make the use of TranslatorMixin.xpath_pseudo_element explicit

https://lgtm.com/rules/7860084/