### PR TITLE
Create docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-notfound-page
+sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,7 @@ commands =
 
 [docs]
 changedir = docs
-deps =
-    sphinx
-    sphinx-notfound-page
-    sphinx_rtd_theme
+deps = -rdocs/requirements.txt
 
 [testenv:docs]
 changedir = {[docs]changedir}


### PR DESCRIPTION
With #169 I broke the documentation build by introducing a new requirement that is not installed in Read the Docs by default.

After this change, I count on fixing the Read the Docs build by making it install the requirements from `docs/requirements.txt`.