### PR TITLE
Add a test for billion laughs attacks

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
+psutil
 pytest
 pytest-cov

--- a/tests/test_xml_attacks.py
+++ b/tests/test_xml_attacks.py
@@ -14,8 +14,8 @@ MiB_1 = 1024 ^ 2
 def _load(attack):
     folder_path = path.dirname(__file__)
     file_path = path.join(folder_path, 'xml_attacks', '{}.xml'.format(attack))
-    with open(file_path) as attack_file:
-        return attack_file.read()
+    with open(file_path, 'rb') as attack_file:
+        return attack_file.read().decode('utf-8')
 
 
 # List of known attacks:

--- a/tests/test_xml_attacks.py
+++ b/tests/test_xml_attacks.py
@@ -1,0 +1,33 @@
+"""Tests for known XML attacks"""
+
+from os import path
+from unittest import TestCase
+
+from psutil import Process
+
+from parsel import Selector
+
+
+MiB_1 = 1024^2
+
+
+def _load(attack):
+    folder_path = path.dirname(__file__)
+    file_path = path.join(folder_path, 'xml_attacks', '{}.xml'.format(attack))
+    with open(file_path) as attack_file:
+        return attack_file.read()
+
+
+# List of known attacks:
+# https://github.com/tiran/defusedxml#python-xml-libraries
+class XMLAttackTestCase(TestCase):
+
+    def test_billion_laughs(self):
+        process = Process()
+        memory_usage_before = process.memory_info().rss
+        selector = Selector(text=_load('billion_laughs'))
+        lolz = selector.css('lolz::text').get()
+        memory_usage_after = process.memory_info().rss
+        memory_change = (memory_usage_after - memory_usage_before)
+        assert memory_change <= MiB_1
+        assert lolz == '&lol9;'

--- a/tests/test_xml_attacks.py
+++ b/tests/test_xml_attacks.py
@@ -8,7 +8,7 @@ from psutil import Process
 from parsel import Selector
 
 
-MiB_1 = 1024^2
+MiB_1 = 1024 ^ 2
 
 
 def _load(attack):

--- a/tests/xml_attacks/billion_laughs.xml
+++ b/tests/xml_attacks/billion_laughs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ELEMENT lolz (#PCDATA)>
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<lolz>&lol9;</lolz>


### PR DESCRIPTION
I’m aiming for eventually covering all XML attacks described at https://github.com/tiran/defusedxml#python-xml-libraries, fixing those that affect Parsel in the process.

This may come specially handy if we eventually support additional parsers, which should also be protected from these attacks.