### PR TITLE
CI fixes, drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       env: TOXENV=py27
     - python: pypy
       env: TOXENV=pypy
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ deploy:
     tags: true
     all_branches: true
     repo: scrapy/parsel
-    condition: $TOXENV == py27
+    condition: $TOXENV == py37

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -22,7 +22,7 @@ def flatten(x):
 
 
 def iflatten(x):
-    """iflatten(sequence) -> iterator
+    """iflatten(sequence) -> Iterator
     Similar to ``.flatten()``, but returns iterator instead"""
     for el in x:
         if _is_listlike(el):

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ def has_environment_marker_platform_impl_support():
 
 install_requires = [
     'w3lib>=1.19.0',
-    'lxml;python_version!="3.4"',
-    'lxml<=4.3.5;python_version=="3.4"',
+    'lxml',
     'six>=1.5.2',
     'cssselect>=0.9'
 ]
@@ -70,7 +69,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3
+envlist = py27, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, pypy, pypy3
+envlist = py27, py35, py36, py37, py38, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
* Python 3.4 support is dropped
* build should be fixed?

Not dropping Python 2.7 yet. If we are to support Scrapy 1.8, it could be nice to have parsel working in Pyhton 2.7 for some time.