### PR TITLE
Keep element's tailing text after removing it

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -376,6 +376,12 @@ class Selector(object):
             )
 
         try:
+            if self.root.tail:
+                previous = self.root.getprevious()
+                if previous is not None:
+                    previous.tail = (previous.tail or '') + self.root.tail
+                else:
+                    parent.text = (parent.text or '') + self.root.tail
             parent.remove(self.root)
         except AttributeError:
             # 'NoneType' object has no attribute 'remove'


### PR DESCRIPTION
Lxml by design removes the text after removed element.
This change removes the element and keeps the trailing text by appending it to the previous element or to the parent.

Fixes #206