### PR TITLE
Create root node memory 210

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -404,6 +404,7 @@ class Selector(object):
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
     __repr__ = __str__
 
+
 def create_root_node_bytes(body, parser_cls, base_url=None):
     """Create root node for text using given parser class.
     """
@@ -413,6 +414,7 @@ def create_root_node_bytes(body, parser_cls, base_url=None):
     if root is None:
         root = etree.fromstring(b'<html/>', parser=parser, base_url=base_url)
     return root
+
 
 class SelectorUtf8Bytes(Selector):
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -403,3 +403,33 @@ class Selector(object):
         data = repr(shorten(self.get(), width=40))
         return "<%s xpath=%r data=%s>" % (type(self).__name__, self._expr, data)
     __repr__ = __str__
+
+def create_root_node_bytes(body, parser_cls, base_url=None):
+    """Create root node for text using given parser class.
+    """
+    parser = parser_cls(recover=True, encoding='utf8')
+    b = body or b'<html/>'
+    root = etree.fromstring(b, parser=parser, base_url=base_url)
+    if root is None:
+        root = etree.fromstring(b'<html/>', parser=parser, base_url=base_url)
+    return root
+
+class SelectorUtf8Bytes(Selector):
+
+    def __init__(self, body=None, type=None, namespaces=None, root=None,
+                 base_url=None, _expr=None):
+        self.type = st = _st(type or self._default_type)
+        self._parser = _ctgroup[st]['_parser']
+        self._csstranslator = _ctgroup[st]['_csstranslator']
+        self._tostring_method = _ctgroup[st]['_tostring_method']
+
+        if body is not None:
+            root = create_root_node_bytes(body, self._parser, base_url=base_url)
+        elif root is None:
+            raise ValueError("Selector needs either text or root argument")
+
+        self.namespaces = dict(self._default_namespaces)
+        if namespaces is not None:
+            self.namespaces.update(namespaces)
+        self.root = root
+        self._expr = _expr


### PR DESCRIPTION
Aimed to fix https://github.com/scrapy/parsel/issues/210

Subclass of Selector created with changed variation of `create_root_node` function.
It accepts `bytes` as input.

Following conditions required to use it in order to prevent extra memory allocations in scrapy mentioned in https://github.com/scrapy/parsel/issues/210#issuecomment-781220999:
1. `response.body` - contain text in utf8 encoding
2.  zero calls of `response.text`.  
`response._cached_ubody` -> `False` indicates that `response.text`   is never called  
 (and no extra memory allocation)

Known usages of `response.text` that can affect memory usage:
1. [`scrapy.utils.response.get_meta_refresh`](https://github.com/scrapy/scrapy/blob/e42d82526a1a519ff1305b189acde064a40fbd8d/scrapy/utils/response.py#L29-L35) used by [`scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware`](https://github.com/scrapy/scrapy/blob/e42d82526a1a519ff1305b189acde064a40fbd8d/scrapy/downloadermiddlewares/redirect.py#L107) - enabled by default in scrapy 2.4  (it needs to be disabled in settings).
2. [`scrapy.downloadermiddlewares.ajaxcrawl.AjaxCrawlMiddleware`](https://github.com/scrapy/scrapy/blob/e42d82526a1a519ff1305b189acde064a40fbd8d/scrapy/downloadermiddlewares/ajaxcrawl.py#L57-L63) - is not enabled by default but it exists in scrapy code.
3. [`sitemap_urls_from_robots`](https://github.com/scrapy/scrapy/blob/e42d82526a1a519ff1305b189acde064a40fbd8d/scrapy/spiders/sitemap.py#L41-L44) in SitemapSpider used to parse sitemap urls in `robots.txt`. 
Custom[ lxml parser implementation](https://github.com/scrapy/scrapy/blob/e42d82526a1a519ff1305b189acde064a40fbd8d/scrapy/utils/sitemap.py#L17-L21) for SitemapSpider class - already create root node for parsing sitemap using `response.body` (bytes) input (not str).
4. response text used to create Selector object on `response.css` and `response.xpath`.

<details>
  <summary>Example usage of SelectorUtf8Bytes(Selector) in scrapy (tested on scrapy 2.4.1)</summary>

```python

import scrapy
from scrapy.crawler import CrawlerProcess
from parsel.selector import SelectorUtf8Bytes

class QuotesToScrapeSpider(scrapy.Spider):
    name = "quotes"
    custom_settings = {
        "DOWNLOAD_DELAY":1,
        "DOWNLOADER_MIDDLEWARES":
            {
                'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': None,
            }
    }
    def start_requests(self):
        yield scrapy.Request(url='https://quotes.toscrape.com', callback=self.parse)

    def parse(self, response):
        print(f"memory allocation (body) as str made: {str(bool(response._cached_ubody))}") # < expected False
        sel = SelectorUtf8Bytes(response.body) # expected encoding Utf8
        links = sel.css("a::attr(href)").getall()
        print(links)
process = CrawlerProcess()
process.crawl(QuotesToScrapeSpider)
process.start()

```  

</details>


<details>
  <summary>Example usage of SelectorUtf8Bytes(Selector) in scrapy (tested on scrapy 2.4.1) - this version of script works on current version of `parsel` </summary>

```python

import scrapy
from scrapy.crawler import CrawlerProcess
from parsel import Selector
from lxml import etree, html

from parsel.csstranslator import HTMLTranslator, GenericTranslator

class SafeXMLParser(etree.XMLParser):
    def __init__(self, *args, **kwargs):
        kwargs.setdefault('resolve_entities', False)
        super(SafeXMLParser, self).__init__(*args, **kwargs)

_ctgroup = {
    'html': {'_parser': html.HTMLParser,
             '_csstranslator': HTMLTranslator(),
             '_tostring_method': 'html'},
    'xml': {'_parser': SafeXMLParser,
            '_csstranslator': GenericTranslator(),
            '_tostring_method': 'xml'},
}

def _st(st):
    if st is None:
        return 'html'
    elif st in _ctgroup:
        return st
    else:
        raise ValueError('Invalid type: %s' % st)

def create_root_node_bytes(body, parser_cls, base_url=None):
    """Create root node for text using given parser class.
    """
    parser = parser_cls(recover=True, encoding='utf8')
    b = body or b'<html/>'
    root = etree.fromstring(b, parser=parser, base_url=base_url)
    if root is None:
        root = etree.fromstring(b'<html/>', parser=parser, base_url=base_url)
    return root

class SelectorUtf8Bytes(Selector):

    def __init__(self, body=None, type=None, namespaces=None, root=None,
                 base_url=None, _expr=None):
        self.type = st = _st(type or self._default_type)
        self._parser = _ctgroup[st]['_parser']
        self._csstranslator = _ctgroup[st]['_csstranslator']
        self._tostring_method = _ctgroup[st]['_tostring_method']

        if body is not None:
            root = create_root_node_bytes(body, self._parser, base_url=base_url)
        elif root is None:
            raise ValueError("Selector needs either text or root argument")

        self.namespaces = dict(self._default_namespaces)
        if namespaces is not None:
            self.namespaces.update(namespaces)
        self.root = root
        self._expr = _expr

class QuotesToScrapeSpider(scrapy.Spider):
    name = "quotes"
    custom_settings = {
        "DOWNLOAD_DELAY":1,
        "DOWNLOADER_MIDDLEWARES":
            {
                'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': None,
            }
    }
    def start_requests(self):
        yield scrapy.Request(url='https://quotes.toscrape.com', callback=self.parse)

    def parse(self, response):
        print(f"memory allocation (body) as str made: {str(bool(response._cached_ubody))}") # < expected False
        sel = SelectorUtf8Bytes(response.body) # expected encoding Utf8
        links = sel.css("a::attr(href)").getall()
        print(links)
process = CrawlerProcess()
process.crawl(QuotesToScrapeSpider)
process.start()

```  

</details>

