### PR TITLE
PoC/discussion: add links()

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -281,6 +281,15 @@ class Selector(object):
         """
         return self.xpath(self._css2xpath(query))
 
+    def links(self):
+        return [
+            link for link in self.xpath('//a/@href').getall()
+            if link and not (
+                    link.startswith('#')
+                    and not link.startswith(('javascript:', 'mailto:'))
+            )
+        ]
+
     def _css2xpath(self, query):
         return self._csstranslator.css_to_xpath(query)
 


### PR DESCRIPTION
This is just an idea I had that I would like to discuss.

I've seen that the [`requests-html` library](https://github.com/psf/requests-html) adds a `links()` method to extract all the URLs in the HTML. In parsel you can easily extract the links by using `css()` or `xpath()`, but there could be some logic that could be simplified by creating a `links()` method (see code).

A possible use would be to use it in conjunction with `scrapy.Response.follow_all()` to easily crawl all URLs in the HTML.

Of course, this should be refactored, properly documented, and tested. Or even converted to a generator. We could also exclude other URL patterns like `tel:` or even add a method parameter to filter the URLS (by a regex pattern like we do in `scrapy.sitemap.SitemapSpider`?) or implement an option to get the absolute links.

So I would like to know what you think about this, if you think it's useful or not and if it should be implemented or not (or alternatively, if it should be implemented directly into the `scrapy.selector.Selector`) :slightly_smiling_face: 

Resolves #26