### PR TITLE
Add PEP 561-style type information

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [run]
 branch = true
 include = parsel/*
+
+[report]
+exclude_lines =
+    @typing.overload

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,6 +20,9 @@ jobs:
         - python-version: 3.8  # Keep in sync with .readthedocs.yml
           env:
             TOXENV: docs
+        - python-version: 3.9
+          env:
+            TOXENV: typing
 
     steps:
     - uses: actions/checkout@v2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CONTRIBUTING.rst
 include NEWS
 include LICENSE
 include README.rst
+include py.typed
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@
 History
 -------
 
+* Add PEP 561-style type information
+
 1.6.0 (2020-05-07)
 ~~~~~~~~~~~~~~~~~~
 

--- a/parsel/__init__.py
+++ b/parsel/__init__.py
@@ -9,6 +9,13 @@ __version__ = '1.6.0'
 
 from parsel.selector import Selector, SelectorList  # NOQA
 from parsel.csstranslator import css2xpath  # NOQA
-from parsel import xpathfuncs # NOQA
+from parsel import xpathfuncs  # NOQA
+
+__all__ = [
+    'Selector',
+    'SelectorList',
+    'css2xpath',
+    'xpathfuncs',
+]
 
 xpathfuncs.setup()

--- a/parsel/__init__.py
+++ b/parsel/__init__.py
@@ -6,16 +6,15 @@ or CSS selectors
 __author__ = 'Scrapy project'
 __email__ = 'info@scrapy.org'
 __version__ = '1.6.0'
-
-from parsel.selector import Selector, SelectorList  # NOQA
-from parsel.csstranslator import css2xpath  # NOQA
-from parsel import xpathfuncs  # NOQA
-
 __all__ = [
     'Selector',
     'SelectorList',
     'css2xpath',
     'xpathfuncs',
 ]
+
+from parsel.selector import Selector, SelectorList  # NOQA
+from parsel.csstranslator import css2xpath  # NOQA
+from parsel import xpathfuncs  # NOQA
 
 xpathfuncs.setup()

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -3,7 +3,7 @@ XPath selectors based on lxml
 """
 
 import typing
-from typing import Any, Dict, Generic, List, Optional, Mapping, Pattern, Union
+from typing import Any, Dict, List, Optional, Mapping, Pattern, Union
 
 from lxml import etree, html
 

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, List, Pattern, Union
 from w3lib.html import replace_entities as w3lib_replace_entities
 
 
@@ -31,7 +32,7 @@ def iflatten(x):
             yield el
 
 
-def _is_listlike(x):
+def _is_listlike(x: Any) -> bool:
     """
     >>> _is_listlike("foo")
     False
@@ -55,7 +56,8 @@ def _is_listlike(x):
     return hasattr(x, "__iter__") and not isinstance(x, (str, bytes))
 
 
-def extract_regex(regex, text, replace_entities=True):
+def extract_regex(regex: Union[str, Pattern[str]], text: str,
+                  replace_entities: bool = True) -> List[str]:
     """Extract a list of unicode strings from the given text/encoding using the following policies:
     * if the regex contains a named group called "extract" that will be returned
     * if the regex contains multiple numbered groups, all those will be returned (flattened)
@@ -82,7 +84,7 @@ def extract_regex(regex, text, replace_entities=True):
     return [w3lib_replace_entities(s, keep=['lt', 'amp']) for s in strings]
 
 
-def shorten(text, width, suffix='...'):
+def shorten(text: str, width: int, suffix: str = '...') -> str:
     """Truncate the given text to fit in the given width."""
     if len(text) <= width:
         return text

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+ignore=tests/typing
 persistent=no
 
 [MESSAGES CONTROL]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ flake8-ignore =
     tests/test_selector_csstranslator.py E501
     tests/test_utils.py E501
     tests/test_xpathfuncs.py E501
+    tests/typing/*.py E F

--- a/tests/typing/selector.py
+++ b/tests/typing/selector.py
@@ -1,0 +1,52 @@
+# Basic usage of the Selector, strongly typed to test the typing of parsel's API.
+import re
+from parsel import Selector
+
+def correct() -> None:
+    selector = Selector(
+        text='<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+
+    li_values: list[str] = selector.css('li').getall()
+    selector.re_first(re.compile(r'[32]'), '').strip()
+    xpath_values: list[str] = selector.xpath(
+        "//somens:a/text()",
+        namespaces={"somens": "http://scrapy.org"}).extract()
+
+    class MySelector(Selector):
+
+        def my_own_func(self) -> int:
+            return 3
+
+    my_selector = MySelector()
+    res: int = my_selector.my_own_func()
+    sub_res: int = my_selector.xpath("//somens:a/text()")[0].my_own_func()
+
+# Negative checks: all the code lines below have typing errors.
+# the "# type: ignore" comment makes sure that mypy identifies them as errors.
+
+def incorrect() -> None:
+    selector = Selector(
+        text='<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>')
+
+    # Wrong query type in css.
+    selector.css(5).getall()  # type: ignore
+
+    # Cannot assign a list of str to an int.
+    li_values: int = selector.css('li').getall()  # type: ignore
+
+    # Cannot use a string to define namespaces in xpath.
+    selector.xpath(
+        "//somens:a/text()",
+        namespaces='{"somens": "http://scrapy.org"}').extract()  # type: ignore
+
+    # Typo in the extract method name.
+    selector.css('li').extact()  # type: ignore
+
+    class MySelector(Selector):
+
+        def my_own_func(self) -> int:
+            return 3
+
+    my_selector = MySelector()
+    res: str = my_selector.my_own_func()  # type: ignore
+    sub_res: str = my_selector.xpath("//somens:a/text()")[0].my_own_func()  # type: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,13 @@ deps =
 commands =
     pytest --flake8
 
+[testenv:typing]
+deps =
+    {[testenv]deps}
+    mypy
+commands =
+    mypy {posargs:tests} --warn-unused-ignores --ignore-missing-imports
+
 [testenv:pylint]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Note that I'm not sure how to correctly add the files in the package. The `*.pyi` files need to be installed, so as the empty `py.typed` file.

As for the types, we've been using them for a while, with `scrapy` types as well. They are not complete but it's a start, and there's no reason for those types to live in our repo when they can benefit others.