### PR TITLE
Add support for regex flags in `.re()` and `.re_first()` methods

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -364,7 +364,7 @@ You can also use compiled regular expressions with both methods::
     >>> import re
     >>> regex = re.compile(r'Name:\s*(.*)')
     >>> selector.xpath('//a[contains(@href, "image")]/text()').re_first(regex)
-    'My image 1'
+    'My image 1 '
 
 As well as adding regex flags with the ``flags`` argument.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -359,6 +359,15 @@ Use it to extract just the first matching string::
     >>> selector.xpath('//a[contains(@href, "image")]/text()').re_first(r'Name:\s*(.*)')
     'My image 1 '
 
+You can also use compiled regular expressions with both methods::
+
+    >>> import re
+    >>> regex = re.compile(r'Name:\s*(.*)')
+    >>> selector.xpath('//a[contains(@href, "image")]/text()').re_first(regex)
+    'My image 1'
+
+As well as adding regex flags with the ``flags`` argument.
+
 .. _topics-selectors-relative-xpaths:
 
 Working with relative XPaths

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -119,7 +119,10 @@ class SelectorList(List[_SelectorType]):
         return self.__class__(flatten([x.css(query) for x in self]))
 
     def re(
-        self, regex: Union[str, Pattern[str]], replace_entities: bool = True
+        self,
+        regex: Union[str, Pattern[str]],
+        replace_entities: bool = True,
+        flags: int = 0,
     ) -> List[str]:
         """
         Call the ``.re()`` method for each element in this list and return
@@ -129,8 +132,14 @@ class SelectorList(List[_SelectorType]):
         corresponding character (except for ``&amp;`` and ``&lt;``.
         Passing ``replace_entities`` as ``False`` switches off these
         replacements.
+
+        It is possible to provide regex flags using the `flags` argument. They
+        will be applied only if the provided regex is not a compiled regular
+        expression.
         """
-        return flatten([x.re(regex, replace_entities=replace_entities) for x in self])
+        return flatten(
+            [x.re(regex, replace_entities=replace_entities, flags=flags) for x in self]
+        )
 
     @typing.overload
     def re_first(
@@ -138,6 +147,7 @@ class SelectorList(List[_SelectorType]):
         regex: Union[str, Pattern[str]],
         default: None = None,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> Optional[str]:
         pass
 
@@ -147,6 +157,7 @@ class SelectorList(List[_SelectorType]):
         regex: Union[str, Pattern[str]],
         default: str,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> str:
         pass
 
@@ -155,6 +166,7 @@ class SelectorList(List[_SelectorType]):
         regex: Union[str, Pattern[str]],
         default: Optional[str] = None,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> Optional[str]:
         """
         Call the ``.re()`` method for the first element in this list and
@@ -168,7 +180,7 @@ class SelectorList(List[_SelectorType]):
         replacements.
         """
         for el in iflatten(
-            x.re(regex, replace_entities=replace_entities) for x in self
+            x.re(regex, replace_entities=replace_entities, flags=flags) for x in self
         ):
             return el
         return default
@@ -358,21 +370,30 @@ class Selector:
         return self._csstranslator.css_to_xpath(query)
 
     def re(
-        self, regex: Union[str, Pattern[str]], replace_entities: bool = True
+        self,
+        regex: Union[str, Pattern[str]],
+        replace_entities: bool = True,
+        flags: int = 0,
     ) -> List[str]:
         """
         Apply the given regex and return a list of unicode strings with the
         matches.
 
         ``regex`` can be either a compiled regular expression or a string which
-        will be compiled to a regular expression using ``re.compile(regex)``.
+        will be compiled to a regular expression using ``re.compile()``.
 
         By default, character entity references are replaced by their
         corresponding character (except for ``&amp;`` and ``&lt;``).
         Passing ``replace_entities`` as ``False`` switches off these
         replacements.
+
+        It is possible to provide regex flags using the `flags` argument. They
+        will be applied only if the provided regex is not a compiled regular
+        expression.
         """
-        return extract_regex(regex, self.get(), replace_entities=replace_entities)
+        return extract_regex(
+            regex, self.get(), replace_entities=replace_entities, flags=flags
+        )
 
     @typing.overload
     def re_first(
@@ -380,6 +401,7 @@ class Selector:
         regex: Union[str, Pattern[str]],
         default: None = None,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> Optional[str]:
         pass
 
@@ -389,6 +411,7 @@ class Selector:
         regex: Union[str, Pattern[str]],
         default: str,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> str:
         pass
 
@@ -397,6 +420,7 @@ class Selector:
         regex: Union[str, Pattern[str]],
         default: Optional[str] = None,
         replace_entities: bool = True,
+        flags: int = 0,
     ) -> Optional[str]:
         """
         Apply the given regex and return the first unicode string which
@@ -407,9 +431,14 @@ class Selector:
         corresponding character (except for ``&amp;`` and ``&lt;``).
         Passing ``replace_entities`` as ``False`` switches off these
         replacements.
+
+        It is possible to provide regex flags using the `flags` argument. They
+        will be applied only if the provided regex is not a compiled regular
+        expression.
         """
         return next(
-            iflatten(self.re(regex, replace_entities=replace_entities)), default
+            iflatten(self.re(regex, replace_entities=replace_entities, flags=flags)),
+            default,
         )
 
     def get(self) -> str:

--- a/parsel/utils.py
+++ b/parsel/utils.py
@@ -57,15 +57,20 @@ def _is_listlike(x: Any) -> bool:
 
 
 def extract_regex(
-    regex: Union[str, Pattern[str]], text: str, replace_entities: bool = True
+    regex: Union[str, Pattern[str]],
+    text: str,
+    replace_entities: bool = True,
+    flags: int = 0,
 ) -> List[str]:
     """Extract a list of unicode strings from the given text/encoding using the following policies:
+    * if the regex is a string it will be compiled using the provided flags
     * if the regex contains a named group called "extract" that will be returned
     * if the regex contains multiple numbered groups, all those will be returned (flattened)
     * if the regex doesn't contain any group the entire regex matching is returned
     """
     if isinstance(regex, str):
-        regex = re.compile(regex, re.UNICODE)
+        flags |= re.UNICODE
+        regex = re.compile(regex, flags)
 
     if "extract" in regex.groupindex:
         # named group

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -318,7 +318,7 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(sel.re_first(r"foo"), None)
         self.assertEqual(sel.re_first(r"foo", default="bar"), "bar")
 
-    def test_extract_first_re_default(self) -> None:
+    def test_re_first_default(self) -> None:
         """Test if re_first() returns default value when no results found"""
         body = '<ul><li id="1">1</li><li id="2">2</li></ul>'
         sel = self.sscls(text=body)
@@ -328,6 +328,30 @@ class SelectorTestCase(unittest.TestCase):
         )
         self.assertEqual(
             sel.xpath("/ul/li/text()").re_first(r"\w+", default="missing"), "missing"
+        )
+
+    def test_re_first_flags(self) -> None:
+        body = """
+        <script>
+            function example() {
+            "name": "Adrian",
+            "points": 3,
+            }
+        </script>
+        """
+        sel = self.sscls(text=body)
+
+        self.assertEqual(
+            sel.xpath("//script/text()").re_first(r"example\(\) ({.*})"), None
+        )
+        self.assertEqual(
+            sel.xpath("//script/text()").re_first(
+                r"example\(\) ({.*})", flags=re.DOTALL
+            ),
+            """{
+            "name": "Adrian",
+            "points": 3,
+            }""",
         )
 
     def test_select_unicode_query(self) -> None:
@@ -710,7 +734,6 @@ class SelectorTestCase(unittest.TestCase):
         self.assertEqual(
             x.xpath("//script")[0].re(name_re, replace_entities=False), [expected]
         )
-
         self.assertEqual(
             x.xpath("//script/text()").re_first(name_re, replace_entities=False),
             expected,
@@ -723,6 +746,28 @@ class SelectorTestCase(unittest.TestCase):
         body = "<div>Evento: cumplea\xf1os</div>"
         x = self.sscls(text=body)
         self.assertEqual(x.xpath("//div").re(r"Evento: (\w+)"), ["cumplea\xf1os"])
+
+    def test_re_flags(self) -> None:
+        body = """
+        <script>
+            function example() {
+            "name": "Adrian",
+            "points": 3,
+            }
+        </script>
+        """
+        sel = self.sscls(text=body)
+
+        self.assertEqual(sel.xpath("//script/text()").re(r"example\(\) ({.*})"), [])
+        self.assertEqual(
+            sel.xpath("//script/text()").re(r"example\(\) ({.*})", flags=re.DOTALL),
+            [
+                """{
+            "name": "Adrian",
+            "points": 3,
+            }"""
+            ],
+        )
 
     def test_selector_over_text(self) -> None:
         hs = self.sscls(text="<root>lala</root>")


### PR DESCRIPTION
There are some cases where I need to apply a regex to multiple lines and the only workaround I found was compiling the expression and using a regex flag there.

Look at this example where I want to extract the content of the JavaScript function `example()` (I know the function is not exactly a function, it is just an example):

```python
>>> import re
>>> from parsel import Selector
>>> text = """
...: <script>
...:     function example() {
...:         "name": "Adrian",
...:         "points": 3,
...:     }
...: </script>
...: """
>>> sel = Selector(text=text)

# using regex strings doesn't work
>>> sel.css('script').re_first(r"example\(\) ({.*})")

# I need to compile the function:
>>> regex = re.compile(r"example\(\) ({.*})", flags=re.DOTALL)
>>> sel.css('script').re_first(regex)
'{\n        "name": "Adrian",\n         "points": 3,\n     }'
```

Doing this requires some extra steps that could be avoided by adding support for regex flags to the `re_first()` and `re()` methods. And that's what I did. With this new implementation, you can directly use it like this:
```python
>>> sel.css('script').re_first(r"example\(\) ({.*})", flags=re.DOTALL)
'{\n        "name": "Adrian",\n         "points": 3,\n     }'
```

This could also help a lot when needing to use case-insensitive regexes:
```python
>>> text = 'Price: 1000.00€'
>>> sel = Selector(text=text)

# The next works
>>> sel.re_first(r'Price: ([\d.]+)€')
'1000.00'

# however, when lowering the text it stops working:
>>> text2 = 'price: 1000.00€'
>>> sel2 = Selector(text=text2)
>>> sel2.re_first(r'Price: ([\d.]+)€')

# with the new implementation you can directly do:
>>> sel2.re_first(r'Price: ([\d.]+)€', flags=re.I)
'1000.00'
```

Let me know your thoughts :)