### PR TITLE
modified _st function to detect doc type

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -41,9 +41,12 @@ _ctgroup = {
 }
 
 
-def _st(st: Optional[str]) -> str:
+def _st(st: Optional[str], text) -> str:
     if st is None:
-        return "html"
+        if("<html>" in text and "</html>" in text):
+            return "html"
+        else:
+            return "xml"
     elif st in _ctgroup:
         return st
     else:
@@ -267,7 +270,7 @@ class Selector:
         base_url: Optional[str] = None,
         _expr: Optional[str] = None,
     ) -> None:
-        self.type = st = _st(type or self._default_type)
+        self.type = st = _st(type or self._default_type, text)
         self._parser = _ctgroup[st]["_parser"]
         self._csstranslator = _ctgroup[st]["_csstranslator"]
         self._tostring_method = _ctgroup[st]["_tostring_method"]


### PR DESCRIPTION
This PR modifies **[_st](https://github.com/scrapy/parsel/blob/7ed4b24a9b8ef874c644c6cec01654539bc66cc3/parsel/selector.py#L38)** function to now automatically detect document type when None is passed. Thus, it closes #194 .
<br><br>

## Code Proof
For HTML

```
>>> from parsel import Selector
>>> selector = Selector(text="""<html>
...     <body>
...         <h1>Hello, Parsel!</h1>
...         <ul>
...             <li><a href="http://example.com">Link 1</a></li>
...             <li><a href="http://scrapy.org">Link 2</a></li>
...         </ul>
...     </body>
...     </html>""")
>>> selector.type
'html'
```
For XML
```
>>> from parsel import Selector
>>> selector = Selector(text="""<?xml version = "1.0"?>
... <contactinfo>
...     <address category = "college">
...         <name>G4G</name>
...         <College>Geeksforgeeks</College>
...         <mobile>2345456767</mobile>
...     </address>
... </contactinfo>""")
>>> selector.type
'xml'
```

Signed-off-by: Shivam Shandilya <shivam.stpaulsdarjeeling@gmail.com>