### PR TITLE
Fix PEP 561 typed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include CONTRIBUTING.rst
 include NEWS
 include LICENSE
 include README.rst
-include py.typed
+include parsel/py.typed
 
 recursive-include tests *
 recursive-exclude * __pycache__


### PR DESCRIPTION
As specified by [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information), the `py.typed` file needs to be included in the python package itself.

In this case, if I install the package from the master branch of the project, a static type checker like pyright doesn't find the `py.typed` file and no type is used.

To reproduce:
```bash
$ pip install git+https://github.com/scrapy/parsel.git@master
```
```py3
# t.py
from parsel import Selector

element = Selector("").css("#some_id").get()
reveal_type(element)
```
```bash
$ pyright t.py
...
type of "element" is "Unknown"
...
```

Expected should be: `type of "element" is "str | None"`