### PR TITLE
Add support for the new cssselect API used in :has().

### DIFF
--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -38,8 +38,8 @@ class XPathExpr(OriginalXPathExpr):
 
         return path
 
-    def join(self, combiner, other):
-        super().join(combiner, other)
+    def join(self, combiner, other, *args, **kwargs):
+        super().join(combiner, other, *args, **kwargs)
         self.textnode = other.textnode
         self.attribute = other.attribute
         return self

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         "cssselect>=0.9",
         "lxml",
+        "packaging",
         "w3lib>=1.19.0",
     ],
     python_requires=">=3.7",

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -5,7 +5,7 @@ import unittest
 
 import cssselect
 import pytest
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from parsel.csstranslator import GenericTranslator, HTMLTranslator
 from parsel import Selector
@@ -203,7 +203,7 @@ class CSSSelectorTest(unittest.TestCase):
         )
 
     @pytest.mark.xfail(
-        parse_version(cssselect.__version__) < parse_version("1.2.0"),
+        Version(cssselect.__version__) < Version("1.2.0"),
         reason="Support added in cssselect 1.2.0",
     )
     def test_pseudoclass_has(self):

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -202,7 +202,9 @@ class CSSSelectorTest(unittest.TestCase):
             ['<area shape="default" id="area-nohref">'],
         )
 
-    @pytest.mark.xfail(parse_version(cssselect.__version__) < parse_version("1.2.0"),
-                       reason="Support added in cssselect 1.2.0")
+    @pytest.mark.xfail(
+        parse_version(cssselect.__version__) < parse_version("1.2.0"),
+        reason="Support added in cssselect 1.2.0",
+    )
     def test_pseudoclass_has(self):
         self.assertEqual(self.x("p:has(b)::text"), ["lorem ipsum text"])

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -2,6 +2,11 @@
 Selector tests for cssselect backend
 """
 import unittest
+
+import cssselect
+import pytest
+from pkg_resources import parse_version
+
 from parsel.csstranslator import GenericTranslator, HTMLTranslator
 from parsel import Selector
 from cssselect.parser import SelectorSyntaxError
@@ -196,3 +201,8 @@ class CSSSelectorTest(unittest.TestCase):
             self.sel.css("div").css("area:last-child").extract(),
             ['<area shape="default" id="area-nohref">'],
         )
+
+    @pytest.mark.xfail(parse_version(cssselect.__version__) < parse_version("1.2.0"),
+                       reason="Support added in cssselect 1.2.0")
+    def test_pseudoclass_has(self):
+        self.assertEqual(self.x("p:has(b)::text"), ["lorem ipsum text"])


### PR DESCRIPTION
Probably shouldn't be merged until csselect 1.2.0 is actually released.