### PR TITLE
docs: import parsel after adding its folder to sys.path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-import parsel
-
 
 # Get the project root dir, which is the parent dir of this
 cwd = os.getcwd()
@@ -14,6 +12,8 @@ project_root = os.path.dirname(cwd)
 # This lets us ensure that the source package is imported, and that its
 # version is used.
 sys.path.insert(0, project_root)
+
+import parsel
 
 
 # -- General configuration ---------------------------------------------


### PR DESCRIPTION
In current master docs are using the installed parsel, not the parsel from the repo.