### PR TITLE
Only install typing_extensions on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "jmespath",
         "lxml",
         "packaging",
-        "typing_extensions",
+        "typing_extensions; python_version < '3.8'",
         "w3lib>=1.19.0",
     ],
     python_requires=">=3.7",


### PR DESCRIPTION
https://github.com/scrapy/parsel/pull/181#discussion_r1166050511