### PR TITLE
fix: Bump minimum required version for `cssselect` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "cssselect>=0.9",
+        "cssselect>=1.2.0",
         "jmespath",
         "lxml",
         "packaging",


### PR DESCRIPTION
Closes #276 