### PR TITLE
Support forcing a selector type into a subselector

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -142,7 +142,9 @@ class SelectorList(List[_SelectorType]):
     def __getstate__(self) -> None:
         raise TypeError("can't pickle SelectorList objects")
 
-    def jmespath(self, query: str, *, type: Optional[str] = None, **kwargs: Any) -> "SelectorList[_SelectorType]":
+    def jmespath(
+        self, query: str, *, type: Optional[str] = None, **kwargs: Any
+    ) -> "SelectorList[_SelectorType]":
         """
         Call the ``.jmespath()`` method for each element in this list and return
         their results flattened as another :class:`SelectorList`.
@@ -154,7 +156,9 @@ class SelectorList(List[_SelectorType]):
 
             selector.jmespath('author.name', options=jmespath.Options(dict_cls=collections.OrderedDict))
         """
-        return self.__class__(flatten([x.jmespath(query, type=type, **kwargs) for x in self]))
+        return self.__class__(
+            flatten([x.jmespath(query, type=type, **kwargs) for x in self])
+        )
 
     def xpath(
         self,
@@ -181,10 +185,19 @@ class SelectorList(List[_SelectorType]):
             selector.xpath('//a[href=$url]', url="http://www.example.com")
         """
         return self.__class__(
-            flatten([x.xpath(xpath, namespaces=namespaces, type=type, **kwargs) for x in self])
+            flatten(
+                [
+                    x.xpath(xpath, namespaces=namespaces, type=type, **kwargs)
+                    for x in self
+                ]
+            )
         )
 
-    def css(self, query: str, type: Optional[str] = None,) -> "SelectorList[_SelectorType]":
+    def css(
+        self,
+        query: str,
+        type: Optional[str] = None,
+    ) -> "SelectorList[_SelectorType]":
         """
         Call the ``.css()`` method for each element in this list and return
         their results flattened as another :class:`SelectorList`.
@@ -644,7 +657,9 @@ class Selector:
         ]
         return typing.cast(SelectorList[_SelectorType], self.selectorlist_cls(result))
 
-    def css(self: _SelectorType, query: str, type: Optional[str] = None) -> SelectorList[_SelectorType]:
+    def css(
+        self: _SelectorType, query: str, type: Optional[str] = None
+    ) -> SelectorList[_SelectorType]:
         """
         Apply the given CSS selector and return a :class:`SelectorList` instance.
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -508,7 +508,7 @@ class Selector:
         self._expr = _expr
         self._huge_tree = huge_tree
         self._text = text
-        self._text_lazy_html_root = None
+        self._text_lazy_html_root: Optional[etree._Element] = None
 
     def __getstate__(self) -> Any:
         raise TypeError("can't pickle Selector objects")
@@ -610,7 +610,8 @@ class Selector:
             try:
                 if self._text_lazy_html_root is None:
                     self._text_lazy_html_root = self._get_root(self.root or "", type="html")
-                xpathev = self._text_lazy_html_root.xpath
+                if self._text_lazy_html_root is not None:
+                    xpathev = self._text_lazy_html_root.xpath
             except AttributeError:
                 return typing.cast(
                     SelectorList[_SelectorType], self.selectorlist_cls([])

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1007,6 +1007,35 @@ class SelectorTestCase(unittest.TestCase):
         self.assertIsSelectorList(sel.css("li"))
         self.assertEqual(sel.css("li::text").getall(), ["2", "3"])
 
+    def test_remove_selector_from_html_in_text(self) -> None:
+        html = (
+            "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
+        )
+        expect_result = "<html><body><p>hello world</p></body></html>"
+        sel = self.sscls(text=html, type="text")
+        self.assertEqual(sel.type, "text")
+        li_sel_list = sel.css("style")
+        li_sel_list.drop()
+        self.assertEqual(sel.get(), expect_result)
+        # The type of the parent selector should not change
+        self.assertEqual(sel.type, "text")
+
+    def test_remove_selector_from_html_in_json(self) -> None:
+        json_str = """{
+            "title": "hello world",
+            "body": "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
+        }
+        """
+        expect_result = "<html><body><p>hello world</p></body></html>"
+        sel = self.sscls(text=json_str)
+        html_sel = sel.jmespath("body")[0]
+        self.assertEqual(html_sel.type, "text")
+        li_sel_list = html_sel.css("style")
+        li_sel_list.drop()
+        self.assertEqual(html_sel.get(), expect_result)
+        # The type of the parent selector should not change
+        self.assertEqual(html_sel.type, "text")
+
     def test_remove_pseudo_element_selector_list(self) -> None:
         sel = self.sscls(
             text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1007,20 +1007,7 @@ class SelectorTestCase(unittest.TestCase):
         self.assertIsSelectorList(sel.css("li"))
         self.assertEqual(sel.css("li::text").getall(), ["2", "3"])
 
-    def test_remove_selector_from_html_in_text(self) -> None:
-        html = (
-            "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
-        )
-        expect_result = "<html><body><p>hello world</p></body></html>"
-        sel = self.sscls(text=html, type="html")
-        self.assertEqual(sel.type, "html")
-        li_sel_list = sel.css("style")
-        li_sel_list.drop()
-        self.assertEqual(sel.get(), expect_result)
-        # The type of the parent selector should not change
-        self.assertEqual(sel.type, "html")
-
-    def test_remove_selector_from_html_in_json(self) -> None:
+    def test_remove_selector_from_nested_html(self) -> None:
         json_str = """{
             "title": "hello world",
             "body": "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
@@ -1028,6 +1015,8 @@ class SelectorTestCase(unittest.TestCase):
         """
         expect_result = "<html><body><p>hello world</p></body></html>"
         sel = self.sscls(text=json_str)
+        # We need to force the selector type to HTML to make that functionality
+        # readily available.
         html_sel = sel.jmespath("body", type="html")[0]
         self.assertEqual(html_sel.type, "html")
         li_sel_list = html_sel.css("style")

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1007,6 +1007,34 @@ class SelectorTestCase(unittest.TestCase):
         self.assertIsSelectorList(sel.css("li"))
         self.assertEqual(sel.css("li::text").getall(), ["2", "3"])
 
+    def test_remove_selector_from_html_in_text(self) -> None:
+        html = "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
+        expect_result = "<html><body><p>hello world</p></body></html>"
+        sel = self.sscls(text=html, type="text")
+        self.assertEqual(sel.type, "text")
+        li_sel_list = sel.css("style")
+        li_sel_list.drop()
+        self.assertEqual(sel.get(), expect_result)
+        # The type of the parent selector should not change
+        self.assertEqual(sel.type, "text")
+
+    def test_remove_selector_from_html_in_json(self) -> None:
+        json_str = """{
+            "title": "hello world",
+            "body": "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
+        }
+        """
+        expect_result = "<html><body><p>hello world</p></body></html>"
+        sel = self.sscls(text=json_str)
+        html_sel = sel.jmespath("body")[0]
+        self.assertEqual(html_sel.type, "text")
+        li_sel_list = html_sel.css("style")
+        li_sel_list.drop()
+        self.assertEqual(html_sel.get(), expect_result)
+        # The type of the parent selector should not change
+        self.assertEqual(html_sel.type, "text")
+
+
     def test_remove_pseudo_element_selector_list(self) -> None:
         sel = self.sscls(
             text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1012,13 +1012,13 @@ class SelectorTestCase(unittest.TestCase):
             "<html><body><style>p{color:red;}</style><p>hello world</p></body></html>"
         )
         expect_result = "<html><body><p>hello world</p></body></html>"
-        sel = self.sscls(text=html, type="text")
-        self.assertEqual(sel.type, "text")
+        sel = self.sscls(text=html, type="html")
+        self.assertEqual(sel.type, "html")
         li_sel_list = sel.css("style")
         li_sel_list.drop()
         self.assertEqual(sel.get(), expect_result)
         # The type of the parent selector should not change
-        self.assertEqual(sel.type, "text")
+        self.assertEqual(sel.type, "html")
 
     def test_remove_selector_from_html_in_json(self) -> None:
         json_str = """{
@@ -1028,13 +1028,13 @@ class SelectorTestCase(unittest.TestCase):
         """
         expect_result = "<html><body><p>hello world</p></body></html>"
         sel = self.sscls(text=json_str)
-        html_sel = sel.jmespath("body")[0]
-        self.assertEqual(html_sel.type, "text")
+        html_sel = sel.jmespath("body", type="html")[0]
+        self.assertEqual(html_sel.type, "html")
         li_sel_list = html_sel.css("style")
         li_sel_list.drop()
         self.assertEqual(html_sel.get(), expect_result)
         # The type of the parent selector should not change
-        self.assertEqual(html_sel.type, "text")
+        self.assertEqual(html_sel.type, "html")
 
     def test_remove_pseudo_element_selector_list(self) -> None:
         sel = self.sscls(


### PR DESCRIPTION
Alternative to #298.

I’m not sure which one is the better approach, though.

But supporting this feature was part of one of the original iterations of JMESPath support, and [it was removed at some point because we saw no use for it](https://github.com/scrapy/parsel/pull/181#discussion_r911574970); it feels like this is a use case to justify its addition.

Fixes #297, resolves #298.