### PR TITLE
Enhance JSON selector: support for attrib and remove_namespaces

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -745,6 +745,7 @@ class Selector:
                     el.attrib[an.split("}", 1)[1]] = el.attrib.pop(an)
         # remove namespace declarations
         etree.cleanup_namespaces(self.root)
+        return None
 
     def drop(self) -> None:
         """

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -734,7 +734,7 @@ class Selector:
         For JSON selectors, this method does nothing (fails gracefully).
         """
         if self.type == "json":
-            return
+            return None
 
         for el in self.root.iter("*"):
             if el.tag.startswith("{"):

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -731,7 +731,11 @@ class Selector:
         """
         Remove all namespaces, allowing to traverse the document using
         namespace-less xpaths. See :ref:`removing-namespaces`.
+        For JSON selectors, this method does nothing (fails gracefully).
         """
+        if self.type == "json":
+            return
+
         for el in self.root.iter("*"):
             if el.tag.startswith("{"):
                 el.tag = el.tag.split("}", 1)[1]
@@ -773,7 +777,13 @@ class Selector:
 
     @property
     def attrib(self) -> dict[str, str]:
-        """Return the attributes dictionary for underlying element."""
+        """
+        Return the attributes dictionary for underlying element.
+        For JSON selectors, return an empty dict (fails gracefully)
+        """
+        if self.type == "json":
+            return {}
+
         return dict(self.root.attrib)
 
     def __bool__(self) -> bool:

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -731,7 +731,7 @@ class Selector:
         """
         Remove all namespaces, allowing to traverse the document using
         namespace-less xpaths. See :ref:`removing-namespaces`.
-        For JSON selectors, this method does nothing (fails gracefully).
+        For JSON selectors, this method does nothing.
         """
         if self.type == "json":
             return
@@ -779,7 +779,7 @@ class Selector:
     def attrib(self) -> dict[str, str]:
         """
         Return the attributes dictionary for underlying element.
-        For JSON selectors, return an empty dict (fails gracefully)
+        For JSON selectors, return an empty dict.
         """
         if self.type == "json":
             return {}

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -734,7 +734,7 @@ class Selector:
         For JSON selectors, this method does nothing (fails gracefully).
         """
         if self.type == "json":
-            return None
+            return
 
         for el in self.root.iter("*"):
             if el.tag.startswith("{"):
@@ -745,7 +745,6 @@ class Selector:
                     el.attrib[an.split("}", 1)[1]] = el.attrib.pop(an)
         # remove namespace declarations
         etree.cleanup_namespaces(self.root)
-        return None
 
     def drop(self) -> None:
         """

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1204,6 +1204,14 @@ class SelectorTestCase(unittest.TestCase):
         selector = Selector(body=bytearray("<h1>Hello World</h1>", "utf-8"))
         assert selector.xpath("//h1/text()").get() == "Hello World"
 
+    def test_remove_namespace_json(self) -> None:
+        sel = self.sscls(text='{"key": "value"}', type="json")
+        self.assertIsNone(sel.remove_namespaces())
+
+    def test_attrib_empty_json(self) -> None:
+        sel = self.sscls(text='{"key": "value"}', type="json")
+        self.assertEqual(sel.attrib, {})
+
 
 class ExsltTestCase(unittest.TestCase):
     sscls = Selector

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1206,7 +1206,7 @@ class SelectorTestCase(unittest.TestCase):
 
     def test_remove_namespace_json(self) -> None:
         sel = self.sscls(text='{"key": "value"}', type="json")
-        self.assertIsNone(sel.remove_namespaces())
+        sel.remove_namespaces()
 
     def test_attrib_empty_json(self) -> None:
         sel = self.sscls(text='{"key": "value"}', type="json")


### PR DESCRIPTION
Adds support for JSON selectors by:
- Returning an empty dict for attrib
- Making remove_namespaces() no-op for JSON selectors

fixes #295