### PR TITLE
Fix getall() return type annotation: list[str] -> list[Any]

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -246,7 +246,7 @@ class SelectorList(list[_SelectorType]):
             return typing.cast("str", el)
         return default
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
         Call the ``.get()`` method for each element is this list and return
         their results flattened, as a list of strings.
@@ -721,7 +721,7 @@ class Selector:
 
     extract = get
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
         Serialize and return the matched node in a 1-element list of strings.
         """


### PR DESCRIPTION
Fixes #325.

`Selector.get()` and `SelectorList.get()` both return `Any` — this was correctly widened when JMESPath/JSON selector support was added (a JMESPath expression can return a list, dict, int, etc.).

However, `getall()` in both `SelectorList` and `Selector` still claims `list[str]`, even though it just calls `get()` internally:

```python
# current (wrong):
def getall(self) -> list[str]:
    return [x.get() for x in self]  # x.get() is Any, not str

# fixed:
def getall(self) -> list[Any]:
    return [x.get() for x in self]
```

This is a pure annotation fix with zero runtime behaviour change. It removes false type-checker errors when using JMESPath selectors that return non-string values. `Any` is already imported in the file.
