### PR TITLE
Type selector output as object

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 
 _SelectorType = TypeVar("_SelectorType", bound="Selector")
+_DefaultType = TypeVar("_DefaultType")
 _ParserType: TypeAlias = etree.XMLParser | etree.HTMLParser
 # simplified _OutputMethodArg from types-lxml
 _TostringMethodType = Literal[
@@ -246,24 +247,24 @@ class SelectorList(list[_SelectorType]):
             return typing.cast("str", el)
         return default
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[object]:
         """
         Call the ``.get()`` method for each element is this list and return
-        their results flattened, as a list of strings.
+        their results flattened.
         """
         return [x.get() for x in self]
 
     extract = getall
 
     @typing.overload
-    def get(self, default: None = None) -> str | None:
+    def get(self, default: None = None) -> object | None:
         pass
 
     @typing.overload
-    def get(self, default: str) -> str:
+    def get(self, default: _DefaultType) -> object | _DefaultType:
         pass
 
-    def get(self, default: str | None = None) -> Any:
+    def get(self, default: _DefaultType | None = None) -> object | _DefaultType | None:
         """
         Return the result of ``.get()`` for the first element in this list.
         If the list is empty, return the default value.
@@ -654,7 +655,7 @@ class Selector:
         Passing ``replace_entities`` as ``False`` switches off these
         replacements.
         """
-        data = self.get()
+        data = typing.cast("str", self.get())
         return extract_regex(regex, data, replace_entities=replace_entities)
 
     @typing.overload
@@ -696,7 +697,7 @@ class Selector:
             default,
         )
 
-    def get(self) -> Any:
+    def get(self) -> object:
         """
         Serialize and return the matched nodes.
 
@@ -721,9 +722,9 @@ class Selector:
 
     extract = get
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[object]:
         """
-        Serialize and return the matched node in a 1-element list of strings.
+        Serialize and return the matched node in a 1-element list.
         """
         return [self.get()]
 

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -5,7 +5,7 @@ Selector tests for cssselect backend
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, cast
 
 import cssselect
 import pytest
@@ -173,7 +173,11 @@ class TestCSSSelector:
     sel = Selector(text=HTMLBODY)
 
     def x(self, *a: Any, **kw: Any) -> list[str]:
-        return [v.strip() for v in self.sel.css(*a, **kw).extract() if v.strip()]
+        return [
+            value.strip()
+            for v in self.sel.css(*a, **kw).extract()
+            if (value := cast("str", v)).strip()
+        ]
 
     def test_selector_simple(self) -> None:
         for x in self.sel.css("input"):

--- a/tests/typing/selector.py
+++ b/tests/typing/selector.py
@@ -11,11 +11,14 @@ def correct() -> None:
         text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"
     )
 
-    li_values: list[str] = selector.css("li").getall()
+    li_values: list[object] = selector.css("li").getall()
     selector.re_first(re.compile(r"[32]"), "").strip()
-    xpath_values: list[str] = selector.xpath(
+    xpath_values: list[object] = selector.xpath(
         "//somens:a/text()", namespaces={"somens": "http://scrapy.org"}
     ).extract()
+    jmes_value: object | None = Selector(text='{"age": 18}', type="json").jmespath(
+        "age"
+    ).get()
 
     class MySelector(Selector):
         def my_own_func(self) -> int:
@@ -38,8 +41,12 @@ def incorrect() -> None:
     # Wrong query type in css.
     selector.css(5).getall()  # type: ignore[arg-type]
 
-    # Cannot assign a list of str to an int.
+    # Cannot assign a list of objects to an int.
     li_values: int = selector.css("li").getall()  # type: ignore[assignment]
+
+    # Cannot assume selector output is always str.
+    string_values: list[str] = selector.css("li").getall()  # type: ignore[assignment]
+    string_value: str = selector.css("li").get()  # type: ignore[assignment]
 
     # Cannot use a string to define namespaces in xpath.
     selector.xpath(


### PR DESCRIPTION
Fixes #325.

`Selector.get()` can return non-string values for JSON/JMESPath selectors, but a few related type hints still described selector output as `str`/`list[str]`. This updates `Selector.getall()` and `SelectorList.get()` / `getall()` to use `object`-based return types, and adjusts the typing tests so code does not assume selector output is always a string.

The runtime behavior is unchanged.

Checks run:

```
uv run --with tox tox -e typing
uv run --with ruff ruff check parsel/selector.py tests/typing/selector.py tests/test_selector_csstranslator.py
uv run --with pytest pytest tests/test_selector_jmespath.py tests/test_selector_csstranslator.py -q
uv run --with tox tox -e py312 -- tests/test_selector_jmespath.py tests/test_selector.py -k "getall_alias or jmespath"
```