### PR TITLE
Drop dead support for pre huge_tree lxml.

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -19,7 +19,6 @@ from typing import (
 
 import jmespath
 from lxml import etree, html
-from packaging.version import Version
 
 from .csstranslator import GenericTranslator, HTMLTranslator
 from .utils import extract_regex, flatten, iflatten, shorten
@@ -39,10 +38,6 @@ _TostringMethodType = Literal[
     "html",
     "xml",
 ]
-
-lxml_version = Version(etree.__version__)
-lxml_huge_tree_version = Version("4.2")
-LXML_SUPPORTS_HUGE_TREE = lxml_version >= lxml_huge_tree_version
 
 
 class CannotRemoveElementWithoutRoot(Exception):
@@ -91,7 +86,7 @@ def create_root_node(
     text: str,
     parser_cls: type[_ParserType],
     base_url: str | None = None,
-    huge_tree: bool = LXML_SUPPORTS_HUGE_TREE,
+    huge_tree: bool = True,
     body: bytes = b"",
     encoding: str = "utf-8",
 ) -> etree._Element:
@@ -101,17 +96,13 @@ def create_root_node(
     else:
         body = text.strip().replace("\x00", "").encode(encoding) or b"<html/>"
 
-    if huge_tree and LXML_SUPPORTS_HUGE_TREE:
-        parser = parser_cls(recover=True, encoding=encoding, huge_tree=True)
-        root = etree.fromstring(body, parser=parser, base_url=base_url)
-    else:
-        parser = parser_cls(recover=True, encoding=encoding)
-        root = etree.fromstring(body, parser=parser, base_url=base_url)
+    parser = parser_cls(recover=True, encoding=encoding, huge_tree=huge_tree)
+    root = etree.fromstring(body, parser=parser, base_url=base_url)
+    if not huge_tree:
         for error in parser.error_log:
             if "use XML_PARSE_HUGE option" in error.message:
                 warnings.warn(
-                    f"Input data is too big. Upgrade to lxml "
-                    f"{lxml_huge_tree_version} or later for huge_tree support.",
+                    "Input data is too big. Set huge_tree=True for huge_tree support.",
                     stacklevel=2,
                 )
     if root is None:
@@ -397,11 +388,11 @@ class Selector:
 
     ``huge_tree`` controls the lxml/libxml2 feature that forbids parsing
     certain large documents to protect from possible memory exhaustion. The
-    argument is ``True`` by default if the installed lxml version supports it,
-    which disables the protection to allow parsing such documents. Set it to
-    ``False`` if you want to enable the protection.
-    See `this lxml FAQ entry <https://lxml.de/FAQ.html#is-lxml-vulnerable-to-xml-bombs>`_
-    for more information.
+    argument is ``True`` by default, which disables the protection to allow
+    parsing such documents. Set it to ``False`` if you want to enable the
+    protection. See `this lxml FAQ entry
+    <https://lxml.de/FAQ.html#is-lxml-vulnerable-to-xml-bombs>`_ for more
+    information.
     """
 
     __slots__ = [
@@ -438,7 +429,7 @@ class Selector:
         root: Any | None = _NOT_SET,
         base_url: str | None = None,
         _expr: str | None = None,
-        huge_tree: bool = LXML_SUPPORTS_HUGE_TREE,
+        huge_tree: bool = True,
     ) -> None:
         self.root: Any
         if type not in ("html", "json", "text", "xml", None):
@@ -503,7 +494,7 @@ class Selector:
         self,
         text: str = "",
         base_url: str | None = None,
-        huge_tree: bool = LXML_SUPPORTS_HUGE_TREE,
+        huge_tree: bool = True,
         type_: str | None = None,
         body: bytes = b"",
         encoding: str = "utf-8",

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -9,12 +9,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from lxml import etree
-from packaging.version import Version
 
 from parsel import Selector, SelectorList
 from parsel.selector import (
     _NOT_SET,
-    LXML_SUPPORTS_HUGE_TREE,
     CannotRemoveElementWithoutParent,
     CannotRemoveElementWithoutRoot,
 )
@@ -938,9 +936,6 @@ class TestSelector:
         assert sel.get() == "<html></html>"
 
     def test_deep_nesting(self) -> None:
-        lxml_version = Version(etree.__version__)
-        lxml_huge_tree_version = Version("4.2")
-
         content = """
         <html>
         <body>
@@ -986,16 +981,6 @@ class TestSelector:
         </html>
         """
 
-        # If lxml doesn't support huge trees expect wrong results and a warning
-        if lxml_version < lxml_huge_tree_version:
-            with warnings.catch_warnings(record=True) as w:
-                sel = Selector(text=content)
-                assert "huge_tree" in str(w[0].message)
-                assert len(sel.css("span")) <= 256
-                assert len(sel.css("td")) == 0
-            return
-
-        # Same goes for explicitly disabling huge trees
         with warnings.catch_warnings(record=True) as w:
             sel = Selector(text=content, huge_tree=False)
             assert "huge_tree" in str(w[0].message)
@@ -1227,7 +1212,7 @@ class SelectorBytesInput(Selector):
         root: Any | None = _NOT_SET,
         base_url: str | None = None,
         _expr: str | None = None,
-        huge_tree: bool = LXML_SUPPORTS_HUGE_TREE,
+        huge_tree: bool = True,
     ) -> None:
         if text:
             body = bytes(text, encoding=encoding)


### PR DESCRIPTION
lxml < 4.2 is no longer supported since 1.11.0

I hope the intention of having a warning when huge_tree was set to False is still valid.