### PR TITLE
fix: correct typing for Selector.get()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@
 History
 -------
 
+1.11.1 (unreleased)
+~~~~~~~~~~~~~~~~~~~
+
+* Fixed the type annotations of ``Selector.get()``, ``SelectorList.get()``,
+  ``Selector.getall()``, and ``SelectorList.getall()`` to return ``Any``
+  instead of ``str``, matching the runtime behavior for JMESPath and other
+  selectors that may return non-string values.
+
 1.11.0 (2026-01-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -246,24 +246,24 @@ class SelectorList(list[_SelectorType]):
             return typing.cast("str", el)
         return default
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
         Call the ``.get()`` method for each element is this list and return
-        their results flattened, as a list of strings.
+        their results flattened, as a list.
         """
         return [x.get() for x in self]
 
     extract = getall
 
     @typing.overload
-    def get(self, default: None = None) -> str | None:
+    def get(self, default: None = None) -> Any | None:
         pass
 
     @typing.overload
-    def get(self, default: str) -> str:
+    def get(self, default: Any) -> Any:
         pass
 
-    def get(self, default: str | None = None) -> Any:
+    def get(self, default: Any | None = None) -> Any:
         """
         Return the result of ``.get()`` for the first element in this list.
         If the list is empty, return the default value.
@@ -721,9 +721,9 @@ class Selector:
 
     extract = get
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
-        Serialize and return the matched node in a 1-element list of strings.
+        Serialize and return the matched node in a 1-element list.
         """
         return [self.get()]
 

--- a/tests/typing/selector.py
+++ b/tests/typing/selector.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from parsel import Selector
 
@@ -11,9 +12,9 @@ def correct() -> None:
         text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"
     )
 
-    li_values: list[str] = selector.css("li").getall()
+    li_values: list[Any] = selector.css("li").getall()
     selector.re_first(re.compile(r"[32]"), "").strip()
-    xpath_values: list[str] = selector.xpath(
+    xpath_values: list[Any] = selector.xpath(
         "//somens:a/text()", namespaces={"somens": "http://scrapy.org"}
     ).extract()
 
@@ -24,6 +25,11 @@ def correct() -> None:
     my_selector = MySelector()
     res: int = my_selector.my_own_func()
     sub_res: int = my_selector.xpath("//somens:a/text()")[0].my_own_func()
+
+    json_selector = Selector(text='{"numbers": [1, 2, 3], "nested": {"value": 42}}')
+    number: int = json_selector.jmespath("nested.value").get(default=0)
+    numbers: list[Any] = json_selector.jmespath("numbers[*]").getall()
+    first_number: Any | None = json_selector.jmespath("numbers[0]").get()
 
 
 # Negative checks: all the code lines below have typing errors.


### PR DESCRIPTION
Fixes #325

When JMESPath support was added, `Selector.get()` was widened to `Any` because a JSON selector can return numbers, lists, dicts, and so on. However, `Selector.getall()` and the `SelectorList.get()` / `getall()` variants still claimed `str` / `list[str]`, so code like `selector.jmespath("numbers[*]").getall()` fails type checking even though it runs fine.

This change finishes the annotation update by switching those remaining signatures to `Any` / `list[Any]`, including the `get(default=...)` overloads so a default value of any type is accepted. The issue notes that `object` would be the stricter choice, but `Any` matches what `Selector.get()` already returns and keeps CSS/XPath code that treats results as strings from breaking.

The NEWS entry is updated, and the typing tests now cover JMESPath usage so the wider types are exercised. `tox -e typing` passes locally.