### PR TITLE
fix: treat empty XML text as an empty document

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -97,7 +97,8 @@ def create_root_node(
 ) -> etree._Element:
     """Create root node for text using given parser class."""
     if not text:
-        body = body.replace(b"\x00", b"").strip()
+        # Match whitespace-only text: empty body after strip → empty document.
+        body = body.replace(b"\x00", b"").strip() or b"<html/>"
     else:
         body = text.strip().replace("\x00", "").encode(encoding) or b"<html/>"
 

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -690,6 +690,15 @@ class TestSelector:
     def test_empty_bodies_shouldnt_raise_errors(self) -> None:
         self.sscls(text="").xpath("//text()").extract()
 
+    def test_empty_xml_text_shouldnt_raise_errors(self) -> None:
+        # Empty text with type=xml must match whitespace-only (empty doc), not XMLSyntaxError.
+        sel = self.sscls(text="", type="xml")
+        assert sel.type == "xml"
+        assert sel.get() == "<html/>"
+        assert sel.xpath("//text()").getall() == []
+        ws = self.sscls(text="   ", type="xml")
+        assert ws.get() == "<html/>"
+
     def test_bodies_with_comments_only(self) -> None:
         sel = self.sscls(text="<!-- hello world -->", base_url="http://example.com")
         assert sel.root.base == "http://example.com"


### PR DESCRIPTION
parsel.selector.create_root_node hits XMLSyntaxError when empty text with type=xml. This PR fixes the regression with a focused test covering the case.
