### PR TITLE
fix: normalize encoding aliases before constructing lxml parsers

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -3,6 +3,7 @@ packages."""
 
 from __future__ import annotations
 
+import codecs
 import json
 import typing
 import warnings
@@ -96,6 +97,8 @@ def create_root_node(
     encoding: str = "utf-8",
 ) -> etree._Element:
     """Create root node for text using given parser class."""
+    # lxml rejects some Python codec aliases (e.g. latin-1); use canonical names.
+    encoding = codecs.lookup(encoding).name
     if not text:
         body = body.replace(b"\x00", b"").strip()
     else:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -690,6 +690,14 @@ class TestSelector:
     def test_empty_bodies_shouldnt_raise_errors(self) -> None:
         self.sscls(text="").xpath("//text()").extract()
 
+    def test_latin1_encoding_alias_for_body(self) -> None:
+        # Python's latin-1 alias must work with body=; lxml only accepts latin1/iso8859-1.
+        body = "£".encode("latin-1")
+        sel = self.sscls(text=None, body=body, encoding="latin-1")
+        assert sel.xpath("//body/text()").get() == "£"
+        sel2 = self.sscls(text=None, body=body, encoding="iso-8859-1")
+        assert sel2.xpath("//body/text()").get() == "£"
+
     def test_bodies_with_comments_only(self) -> None:
         sel = self.sscls(text="<!-- hello world -->", base_url="http://example.com")
         assert sel.root.base == "http://example.com"


### PR DESCRIPTION
parsel.selector.create_root_node hits LookupError when encoding=latin-1 body bytes. This PR fixes the regression with a focused test covering the case.
