### PR TITLE
fix: allow jmespath on string and type=text selectors

### DIFF
--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -535,14 +535,14 @@ class Selector:
 
             selector.jmespath('author.name', options=jmespath.Options(dict_cls=collections.OrderedDict))
         """
-        if self.type == "json":
-            if isinstance(self.root, str):
-                # Selector received a JSON string as root.
-                data = _load_json_or_none(self.root)
-            else:
+        if self.type == "json" and not isinstance(self.root, str):
+            data = self.root
+        elif isinstance(self.root, str):
+            try:
+                data = json.loads(self.root)
+            except ValueError:
                 data = self.root
         else:
-            assert self.type in {"html", "xml"}  # nosec
             data = _load_json_or_none(self.root.text)
 
         result = jmespath.search(query, data, **kwargs)

--- a/tests/test_selector_jmespath.py
+++ b/tests/test_selector_jmespath.py
@@ -167,3 +167,24 @@ class TestJMESPath:
             assert selector.type == "json"
             assert selector._text is None
             assert selector.root == root
+
+    def test_jmespath_on_attr_string_root(self) -> None:
+        html = '<div data-json=\'{"z": 9}\'><a href="http://example.com">t</a></div>'
+        sel = Selector(text=html)
+        assert sel.css("a::attr(href)").jmespath("@").get() == "http://example.com"
+        assert cast("int", sel.css("a::attr(href)").jmespath("length(@)").get()) == 18
+        assert cast("int", sel.css("div::attr(data-json)").jmespath("z").get()) == 9
+
+    def test_jmespath_on_type_text(self) -> None:
+        sel = Selector(text='{"a": ["b", "c"]}', type="text")
+        assert sel.jmespath("a").getall() == ["b", "c"]
+        assert sel.jmespath("a").jmespath("length(@)").getall() == [1, 1]
+        assert Selector(text="hello", type="text").jmespath("length(@)").get() == 5
+
+    def test_jmespath_chain_from_html_json_text(self) -> None:
+        html = '<script type="application/json">{"a": ["b", "c"]}</script>'
+        sel = Selector(text=html)
+        assert sel.css("script::text").jmespath("a").jmespath("length(@)").getall() == [
+            1,
+            1,
+        ]


### PR DESCRIPTION
Selector.jmespath hits AttributeError when html/xml string root from ::attr or text(). This PR fixes the regression with a focused test covering the case.
