### PR TITLE
Correct selector extraction return types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@
 History
 -------
 
+1.12.0 (unreleased)
+~~~~~~~~~~~~~~~~~~~
+
+* Fixed return type annotations for ``Selector.get()``, ``Selector.getall()``,
+  ``SelectorList.get()``, and ``SelectorList.getall()`` to account for
+  non-string JSON values.
+
 1.11.0 (2026-01-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -237,24 +237,16 @@ class SelectorList(list[_SelectorType]):
             return typing.cast("str", el)
         return default
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[object]:
         """
         Call the ``.get()`` method for each element in this list and return
-        their results flattened, as a list of strings.
+        their results as a list.
         """
         return [x.get() for x in self]
 
     extract = getall
 
-    @typing.overload
-    def get(self, default: None = None) -> str | None:
-        pass
-
-    @typing.overload
-    def get(self, default: str) -> str:
-        pass
-
-    def get(self, default: str | None = None) -> Any:
+    def get(self, default: object = None) -> object:
         """
         Return the result of ``.get()`` for the first element in this list.
         If the list is empty, return the default value.
@@ -638,7 +630,7 @@ class Selector:
         Passing ``replace_entities`` as ``False`` switches off these
         replacements.
         """
-        data = self.get()
+        data = typing.cast("str", self.get())
         return extract_regex(regex, data, replace_entities=replace_entities)
 
     @typing.overload
@@ -680,7 +672,7 @@ class Selector:
             default,
         )
 
-    def get(self) -> Any:
+    def get(self) -> object:
         """
         Serialize and return the matched nodes.
 
@@ -704,9 +696,9 @@ class Selector:
 
     extract = get
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[object]:
         """
-        Serialize and return the matched node in a 1-element list of strings.
+        Serialize and return the matched node in a 1-element list.
         """
         return [self.get()]
 

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -5,7 +5,7 @@ Selector tests for cssselect backend
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, cast
 
 import cssselect
 import pytest
@@ -173,7 +173,8 @@ class TestCSSSelector:
     sel = Selector(text=HTMLBODY)
 
     def x(self, *a: Any, **kw: Any) -> list[str]:
-        return [v.strip() for v in self.sel.css(*a, **kw).extract() if v.strip()]
+        values = cast("list[str]", self.sel.css(*a, **kw).extract())
+        return [value.strip() for value in values if value.strip()]
 
     def test_selector_simple(self) -> None:
         for x in self.sel.css("input"):

--- a/tests/typing/selector.py
+++ b/tests/typing/selector.py
@@ -11,9 +11,11 @@ def correct() -> None:
         text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"
     )
 
-    li_values: list[str] = selector.css("li").getall()
+    li_values: list[object] = selector.css("li").getall()
+    li_value: object = selector.css("li").get()
+    age: object = Selector(text='{"age": 18}', type="json").jmespath("age").get()
     selector.re_first(re.compile(r"[32]"), "").strip()
-    xpath_values: list[str] = selector.xpath(
+    xpath_values: list[object] = selector.xpath(
         "//somens:a/text()", namespaces={"somens": "http://scrapy.org"}
     ).extract()
 
@@ -38,7 +40,10 @@ def incorrect() -> None:
     # Wrong query type in css.
     selector.css(5).getall()  # type: ignore[arg-type]
 
-    # Cannot assign a list of str to an int.
+    # Selector results are objects because JSON selectors can return any value.
+    string_values: list[str] = selector.css("li").getall()  # type: ignore[assignment]
+
+    # Cannot assign a list of objects to an int.
     li_values: int = selector.css("li").getall()  # type: ignore[assignment]
 
     # Cannot use a string to define namespaces in xpath.


### PR DESCRIPTION
Fixes #325.

JMESPath selectors can return arbitrary JSON values, but several extraction methods still claimed to return only strings. This changes `Selector.get()` and `SelectorList.get()` to return `object`, and their `getall()`/`extract()` counterparts to return `list[object]`.

The strict typing fixture now covers a non-string JMESPath result and verifies that assigning selector results directly to `str`/`list[str]` is rejected. The `re()` implementation uses a typing-only cast because its existing runtime contract still requires a string-serializing selector.

This is intentionally a downstream typing change: code that assumes CSS or XPath extraction is always a string will now need an explicit cast or runtime narrowing. Inferring strings only for CSS/XPath would require a larger content-type generic redesign because the current `Selector` type does not encode its runtime selector type.

Validation:
- `mypy parsel tests` — success, 12 source files
- `python -m pytest docs parsel tests -q` — 393 passed, 2 skipped
- pre-commit checks on all changed files — passed