### PR TITLE
Small pytest cleanup, enable codecov test results.

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -30,3 +30,9 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        report_type: test_results

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -58,3 +58,9 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        report_type: test_results

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -30,3 +30,9 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        report_type: test_results

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pip-log.txt
 nosetests.xml
 htmlcov
 .pytest_cache
+*.junit.xml
 
 # Translations
 *.mo

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,0 @@
-psutil==5.6.3  # https://github.com/giampaolo/psutil/issues/1659#issuecomment-586032229
-pytest
-pytest-cov>=7.0.0
-sybil

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,11 @@ envlist = typing,pylint,docs,twinecheck,pre-commit,py310,py311,py312,py313,py314
 [testenv]
 usedevelop = True
 deps =
-    -r{toxinidir}/tests/requirements.txt
-commands = py.test --cov=parsel --cov-report=xml {posargs:docs parsel tests}
+    psutil
+    pytest
+    pytest-cov>=7.0.0
+    sybil
+commands = pytest --cov=parsel --cov-report=term-missing --cov-report=xml --junitxml=testenv.junit.xml -o junit_family=legacy {posargs:docs parsel tests}
 
 [testenv:typing]
 deps =


### PR DESCRIPTION
I decided to extract the psutil unpinning and requirements simplification from #348