### PR TITLE
Cache CSS-to-XPath translations per instance, not globally

### DIFF
--- a/parsel/csstranslator.py
+++ b/parsel/csstranslator.py
@@ -80,6 +80,31 @@ class TranslatorMixin:
     Currently supported pseudo-elements are ``::text`` and ``::attr(ATTR_NAME)``.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._build_cache()
+
+    # The cache is per instance because translation depends on instance state,
+    # and because a cache shared by all instances, keyed on the instance, keeps
+    # every translator ever used alive.
+    def _build_cache(self) -> None:
+        self._cache = lru_cache(maxsize=256)(self._translate)
+
+    def _translate(self, css: str, prefix: str) -> str:
+        # https://github.com/python/mypy/issues/14757
+        return super().css_to_xpath(css, prefix)  # type: ignore[misc,no-any-return]
+
+    def css_to_xpath(self, css: str, prefix: str = "descendant-or-self::") -> str:
+        return self._cache(css, prefix)
+
+    # The cache holds a reference to a bound method, which cannot be pickled.
+    def __getstate__(self) -> dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if k != "_cache"}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._build_cache()
+
     def xpath_element(self: TranslatorProtocol, selector: Element) -> XPathExpr:
         # https://github.com/python/mypy/issues/14757
         xpath = super().xpath_element(selector)  # type: ignore[safe-super]
@@ -127,15 +152,11 @@ class TranslatorMixin:
 
 
 class GenericTranslator(TranslatorMixin, OriginalGenericTranslator):
-    @lru_cache(maxsize=256)
-    def css_to_xpath(self, css: str, prefix: str = "descendant-or-self::") -> str:
-        return super().css_to_xpath(css, prefix)
+    pass
 
 
 class HTMLTranslator(TranslatorMixin, OriginalHTMLTranslator):
-    @lru_cache(maxsize=256)
-    def css_to_xpath(self, css: str, prefix: str = "descendant-or-self::") -> str:
-        return super().css_to_xpath(css, prefix)
+    pass
 
 
 _translator = HTMLTranslator()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,9 +251,6 @@ ignore = [
     "RUF012",
     # Use of `assert` detected
     "S101",
-
-    # pending: https://github.com/scrapy/parsel/issues/312
-    "B019",
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/test_selector_csstranslator.py
+++ b/tests/test_selector_csstranslator.py
@@ -4,6 +4,9 @@ Selector tests for cssselect backend
 
 from __future__ import annotations
 
+import gc
+import pickle
+import weakref
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -159,6 +162,28 @@ class TestHTMLTranslator(TestTranslatorBase):
 
 class TestGenericTranslator(TestTranslatorBase):
     tr_cls = GenericTranslator
+
+
+@pytest.mark.parametrize("tr_cls", [GenericTranslator, HTMLTranslator])
+class TestTranslatorCache:
+    def test_cache(self, tr_cls: type[GenericTranslator | HTMLTranslator]) -> None:
+        tr = tr_cls()
+        assert tr.css_to_xpath("a::text") == tr.css_to_xpath("a::text")
+        assert tr._cache.cache_info().hits == 1
+
+    def test_garbage_collection(
+        self, tr_cls: type[GenericTranslator | HTMLTranslator]
+    ) -> None:
+        tr = tr_cls()
+        tr.css_to_xpath("a::text")
+        ref = weakref.ref(tr)
+        del tr
+        gc.collect()
+        assert ref() is None
+
+    def test_pickle(self, tr_cls: type[GenericTranslator | HTMLTranslator]) -> None:
+        tr = pickle.loads(pickle.dumps(tr_cls()))  # noqa: S301
+        assert tr.css_to_xpath("a::text") == "descendant-or-self::a/text()"
 
 
 def test_css2xpath() -> None:


### PR DESCRIPTION
Fixes https://github.com/scrapy/parsel/issues/312.