### PR TITLE
Only detect JSON objects and arrays as JSON, and stop ignoring type

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,8 +108,8 @@ So, let's download that page and create a selector for it:
 
    selector = load_selector('selectors-sample1.html')
 
-Since we're dealing with HTML, the default type for Selector, we don't need
-to specify the `type` argument.
+We don't need to specify the `type` argument: Selector detects JSON input, and
+falls back to HTML otherwise.
 
 So, by looking at the :ref:`HTML code <topics-selectors-htmlcode>` of that
 page, let's construct an XPath for selecting the text inside the title tag::

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -298,12 +298,12 @@ def _get_root_and_type_from_bytes(
 ) -> tuple[Any, str]:
     if input_type == "text":
         return body.decode(encoding), input_type
-    if encoding == "utf-8":
+    if input_type in ("json", None) and encoding == "utf-8":
         try:
             data = json.load(BytesIO(body))
         except ValueError:
             data = _NOT_SET
-        if data is not _NOT_SET:
+        if data is not _NOT_SET and (input_type == "json" or _is_json_document(data)):
             return data, "json"
     if input_type == "json":
         return None, "json"
@@ -324,12 +324,13 @@ def _get_root_and_type_from_text(
 ) -> tuple[Any, str]:
     if input_type == "text":
         return text, input_type
-    try:
-        data = json.loads(text)
-    except ValueError:
-        data = _NOT_SET
-    if data is not _NOT_SET:
-        return data, "json"
+    if input_type in ("json", None):
+        try:
+            data = json.loads(text)
+        except ValueError:
+            data = _NOT_SET
+        if data is not _NOT_SET and (input_type == "json" or _is_json_document(data)):
+            return data, "json"
     if input_type == "json":
         return None, "json"
     assert input_type in ("html", "xml", None)  # nosec
@@ -346,17 +347,21 @@ def _get_root_type(root: Any, *, input_type: str | None) -> str:
                 f"and {input_type!r} as type."
             )
         return _xml_or_html(input_type)
-    if isinstance(root, (dict, list)) or _is_valid_json(root):
+    if input_type in {"json", "text"}:
+        return input_type
+    if _is_json_document(root) or _is_json_document(_load_json_or_none(root)):
         return "json"
     return input_type or "json"
 
 
-def _is_valid_json(text: str) -> bool:
-    try:
-        json.loads(text)
-    except (TypeError, ValueError):
-        return False
-    return True
+def _is_json_document(data: Any) -> bool:
+    """Return whether *data* is a JSON object or array.
+
+    Scalar JSON values are valid JSON documents as well, but they are also
+    valid text and HTML, which is what they usually are when type detection
+    gets to see them, so type detection ignores them.
+    """
+    return isinstance(data, (dict, list))
 
 
 def _load_json_or_none(text: str) -> Any:
@@ -380,8 +385,9 @@ class Selector:
     ``body`` is a ``bytes`` or ``bytearray`` object. It can be used together with the
     ``encoding`` argument instead of the ``text`` argument.
 
-    ``type`` defines the selector type. It can be ``"html"`` (default),
-    ``"json"``, ``"xml"`` or ``"text"``.
+    ``type`` defines the selector type. It can be ``"html"``, ``"json"``,
+    ``"xml"`` or ``"text"``. If not specified, the input is handled as
+    ``"json"`` if it is a JSON object or array, and as ``"html"`` otherwise.
 
     ``base_url`` allows setting a URL for the document. This is needed when looking up external entities with relative paths.
     See the documentation for :func:`lxml.etree.fromstring` for more information.

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1013,6 +1013,10 @@ class TestSelector:
         selector = self.sscls('{"a": "b"}', type=type_)
         assert selector.type == type_
 
+    def test_explicit_text_type_beats_json_root(self) -> None:
+        selector = self.sscls(root='{"a": "b"}', type="text")
+        assert selector.type == "text"
+
     def test_html_root(self) -> None:
         root = etree.fromstring("<html/>")
         selector = self.sscls(root=root)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1008,6 +1008,11 @@ class TestSelector:
         assert selector.root == obj
         assert selector.type == "json"
 
+    @pytest.mark.parametrize("type_", ["html", "xml", "text"])
+    def test_explicit_type_beats_json(self, type_: str) -> None:
+        selector = self.sscls('{"a": "b"}', type=type_)
+        assert selector.type == type_
+
     def test_html_root(self) -> None:
         root = etree.fromstring("<html/>")
         selector = self.sscls(root=root)
@@ -1055,12 +1060,12 @@ class TestSelector:
             Selector(root=selector.root, type="json")
 
     def test_json_selector_representation(self) -> None:
-        selector = Selector(text="true")
+        selector = Selector(text="true", type="json")
         assert repr(selector) == "<Selector query=None data='True'>"
         assert str(selector) == "True"
-        selector = Selector(text="1")
-        assert repr(selector) == "<Selector query=None data='1'>"
-        assert str(selector) == "1"
+        selector = Selector(text="[1]")
+        assert repr(selector) == "<Selector query=None data='[1]'>"
+        assert str(selector) == "[1]"
 
     def test_body_bytearray_support(self) -> None:
         selector = Selector(body=bytearray("<h1>Hello World</h1>", "utf-8"))

--- a/tests/test_selector_jmespath.py
+++ b/tests/test_selector_jmespath.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -145,25 +145,46 @@ class TestJMESPath:
             r"(\d+)"
         ) == ["18", "32", "22", "25"]
 
-    def test_json_types(self) -> None:
-        for text, root in (
+    @pytest.mark.parametrize(
+        ("text", "root"),
+        [
             ("{}", {}),
             ('{"a": "b"}', {"a": "b"}),
             ("[]", []),
             ('["a"]', ["a"]),
+        ],
+    )
+    def test_json_types(self, text: str, root: Any) -> None:
+        for input_type in (None, "json"):
+            selector = Selector(text=text, type=input_type, root=_NOT_SET)
+            assert selector.type == "json"
+            assert selector._text == text
+            assert selector.root == root
+
+        selector = Selector(text=None, root=root)
+        assert selector.type == "json"
+        assert selector._text is None
+        assert selector.root == root
+
+    @pytest.mark.parametrize(
+        ("text", "root"),
+        [
             ('""', ""),
             ("0", 0),
             ("1", 1),
             ("true", True),
             ("false", False),
             ("null", None),
-        ):
-            selector = Selector(text=text, root=_NOT_SET)
-            assert selector.type == "json"
-            assert selector._text == text
-            assert selector.root == root
+        ],
+    )
+    def test_json_scalar_types(self, text: str, root: Any) -> None:
+        """Scalar JSON values are only handled as JSON on request, since they
+        are also valid text and HTML."""
+        selector = Selector(text=text, type="json", root=_NOT_SET)
+        assert selector.type == "json"
+        assert selector._text == text
+        assert selector.root == root
 
-            selector = Selector(text=None, root=root)
-            assert selector.type == "json"
-            assert selector._text is None
-            assert selector.root == root
+        selector = Selector(text=text, root=_NOT_SET)
+        assert selector.type == "html"
+        assert selector.xpath("//body/text()").get() == text

--- a/tests/test_selector_jmespath.py
+++ b/tests/test_selector_jmespath.py
@@ -187,4 +187,5 @@ class TestJMESPath:
 
         selector = Selector(text=text, root=_NOT_SET)
         assert selector.type == "html"
-        assert selector.xpath("//body/text()").get() == text
+        # libxml2 may or may not wrap the text into a <p> element.
+        assert selector.xpath("string(//body)").get() == text


### PR DESCRIPTION
Resolves https://github.com/scrapy/parsel/issues/310.