### PR TITLE
Fix get/getall type hints for non-string JMESPath results

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@
 History
 -------
 
+1.12.0 (unreleased)
+~~~~~~~~~~~~~~~~~~~
+
+* Fixed type hints for ``Selector.getall()``, ``SelectorList.get()`` and
+  ``SelectorList.getall()``. They no longer claim a ``str`` result, which is
+  wrong for JMESPath selectors (#325).
+
 1.11.0 (2026-01-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/parsel/selector.py
+++ b/parsel/selector.py
@@ -237,24 +237,27 @@ class SelectorList(list[_SelectorType]):
             return typing.cast("str", el)
         return default
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
         Call the ``.get()`` method for each element in this list and return
-        their results flattened, as a list of strings.
+        their results flattened, as a list.
+
+        For HTML and XML this is a list of strings. JMESPath selectors may
+        return other JSON types.
         """
         return [x.get() for x in self]
 
     extract = getall
 
     @typing.overload
-    def get(self, default: None = None) -> str | None:
+    def get(self, default: None = None) -> Any | None:
         pass
 
     @typing.overload
-    def get(self, default: str) -> str:
+    def get(self, default: Any) -> Any:
         pass
 
-    def get(self, default: str | None = None) -> Any:
+    def get(self, default: Any | None = None) -> Any:
         """
         Return the result of ``.get()`` for the first element in this list.
         If the list is empty, return the default value.
@@ -710,9 +713,12 @@ class Selector:
 
     extract = get
 
-    def getall(self) -> list[str]:
+    def getall(self) -> list[Any]:
         """
-        Serialize and return the matched node in a 1-element list of strings.
+        Serialize and return the matched node in a 1-element list.
+
+        For HTML and XML the list contains a string. JMESPath selectors may
+        return other JSON types.
         """
         return [self.get()]
 

--- a/tests/typing/selector.py
+++ b/tests/typing/selector.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from parsel import Selector
 
@@ -11,11 +12,16 @@ def correct() -> None:
         text="<html><body><ul><li>1</li><li>2</li><li>3</li></ul></body></html>"
     )
 
-    li_values: list[str] = selector.css("li").getall()
+    # get()/getall() are Any because JMESPath can return non-strings.
+    li_values: list[Any] = selector.css("li").getall()
+    first_li: Any | None = selector.css("li").get()
     selector.re_first(re.compile(r"[32]"), "").strip()
-    xpath_values: list[str] = selector.xpath(
+    xpath_values: list[Any] = selector.xpath(
         "//somens:a/text()", namespaces={"somens": "http://scrapy.org"}
     ).extract()
+
+    json_selector = Selector(text='{"n": 1}', type="json")
+    n: Any = json_selector.jmespath("n").get()
 
     class MySelector(Selector):
         def my_own_func(self) -> int:
@@ -38,7 +44,7 @@ def incorrect() -> None:
     # Wrong query type in css.
     selector.css(5).getall()  # type: ignore[arg-type]
 
-    # Cannot assign a list of str to an int.
+    # Cannot assign a list to an int.
     li_values: int = selector.css("li").getall()  # type: ignore[assignment]
 
     # Cannot use a string to define namespaces in xpath.


### PR DESCRIPTION
JMESPath selectors can return numbers, objects, and other JSON values, not just strings. `Selector.get()` was already typed as `Any` for that, but `Selector.getall()`, `SelectorList.getall()`, and the `SelectorList.get()` overloads still claimed `str`.

Type checkers therefore treated a JMESPath `.get()` as `str | None` and hid the real result type.

This updates those leftover hints to `Any`, matching `Selector.get()`, and adjusts the typing tests.

Fixes #325