### PR TITLE
tests: pin how c1 numeric character references extract

### DIFF
--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import pickle
 import re
 import typing
@@ -850,6 +851,33 @@ class TestSelector:
         sel = self.sscls(text=malicious_xml, type="xml")
 
         assert sel.extract() == "<foo>&xxe;</foo>"
+
+    def test_html_c1_character_references(self) -> None:
+        """HTML maps numeric references in the C1 range through the CP1252 table.
+
+        ``&#133;`` is an ellipsis rather than U+0085, which is what browsers show
+        and what the HTML standard requires. ``html.unescape`` implements the same
+        table, so it is used as the reference. See #76.
+        """
+        for code_point in range(0x80, 0xA0):
+            reference = f"&#{code_point};"
+            expected = html.unescape(reference)
+            sel = self.sscls(text=f"<p>{reference}</p>")
+            assert sel.css("p::text").get() == expected, reference
+            assert sel.xpath("//p/text()").get() == expected, reference
+
+    def test_html_c1_character_references_hex_and_named(self) -> None:
+        assert self.sscls(text="<p>&#x85;</p>").css("p::text").get() == "\u2026"
+        assert self.sscls(text="<p>&hellip;</p>").css("p::text").get() == "\u2026"
+
+    def test_xml_keeps_c1_character_references_literal(self) -> None:
+        """XML has no CP1252 remapping, so ``&#133;`` really is U+0085 there.
+
+        This is the behaviour in the original report of #76. It is correct for the
+        XML parser and only the HTML path applies the replacement table.
+        """
+        sel = self.sscls(text="<p>&#133;</p>", type="xml")
+        assert sel.xpath("//p/text()").get() == "\x85"
 
     def test_configure_base_url(self) -> None:
         sel = self.sscls(text="nothing", base_url="http://example.com")


### PR DESCRIPTION
Closes #76.

### what this is

#76 reported that numeric character references in the reserved C1 range came out as the raw code point rather than what a browser shows, so `&#133;` gave `\x85` instead of `…`. That is fixed in libxml2 now, and I have posted the check on the issue.

Nothing in the suite holds it there, though, so this adds the coverage rather than leaving an eight year old behaviour resting on a dependency nobody is pinning for it.

### what is covered

The whole range, not a sample. All 32 code points from `0x80` to `0x9f`, through both the css and the xpath path, compared against `html.unescape`, which implements the same HTML5 replacement table:

```python
for code_point in range(0x80, 0xA0):
    reference = f"&#{code_point};"
    expected = html.unescape(reference)
    sel = self.sscls(text=f"<p>{reference}</p>")
    assert sel.css("p::text").get() == expected, reference
    assert sel.xpath("//p/text()").get() == expected, reference
```

Plus the hex and named forms, since `&#x85;` and `&hellip;` reach the same place by a different route.

### the xml one is deliberate

```python
def test_xml_keeps_c1_character_references_literal(self) -> None:
    sel = self.sscls(text="<p>&#133;</p>", type="xml")
    assert sel.xpath("//p/text()").get() == "\x85"
```

XML has no CP1252 remapping, so `&#133;` really is U+0085 there and the literal code point is correct. That is the behaviour the original report showed, using `etree.fromstring`, which is the XML parser. It is pinned so nobody later "fixes" the XML path to match HTML.

### does it actually catch anything

A regression to the old behaviour differs from the assertion on **27 of the 32** code points. The other five, `0x81`, `0x8d`, `0x8f`, `0x90` and `0x9d`, have no entry in the replacement table, so the literal code point is the right answer for them either way.

### checks

| check | result |
|---|---|
| `pytest tests/` | 302 passed, 2 skipped |
| `ruff format --check` | already formatted |
| `ruff check` | 7 findings repo wide, **the same 7 on master**. one is in the file this touches |
| `mypy parsel tests` | 7 errors in 4 files, **the same 7 on master**. two are in the file this touches |
| `pylint docs parsel tests` | 10.00/10 |
| `pytest docs parsel tests` (the CI target) | 446 passed, 2 skipped |

I stated those two rows loosely the first time, so to be exact. I compared against `origin/master` in a throwaway worktree using the same binaries rather than assuming. The finding sets are identical; the only difference is line numbers, `PLR0917` moving from 1242 to 1270 and the two mypy lines from 11/23 to 12/24, which are exactly my added line counts. Nothing new is attributable to this change.

Both are also local environment artifacts rather than CI signal. `tox.ini` pins `types-lxml`, `types-jmespath` and `types-psutil` for the typing env and none are in my venv, so all 7 mypy errors disappear under CI. Local ruff is 0.16.5 while `.pre-commit-config.yaml` pins v0.15.22, so version skew explains findings CI would not raise.

